### PR TITLE
github-actions: support for only docs

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,33 @@
+# This workflow sets the 'test-windows' and 'builds' status check to success in case it's a docs only PR and ci.yml is not triggered
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Pull Request Validation # The name must be the same as in ci.yml
+
+on:
+  pull_request:
+    paths-ignore: # This expression needs to match the paths ignored on ci.yml.
+      - '**'
+      - '!*.md'
+      - '!*.asciidoc'
+      - '!docs/**'
+
+permissions:
+  contents: read
+
+## Concurrency only allowed in the main branch.
+## So old builds running for old commits within the same Pull Request are cancelled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # dummy steps that allow to bypass those mandatory checks for tests
+  test-windows:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required for docs"'
+
+  # dummy steps that allow to bypass those mandatory checks for tests
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required for docs"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ concurrency:
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
+# NOTE: if you add a new job and it's a mandatory check then
+#       update ci.yml
 jobs:
   test-windows:
     runs-on: windows-latest

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -1,0 +1,27 @@
+# This workflow sets the 'test' status check to success in case it's a docs only PR and e2e.yml is not triggered
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: e2e # The name must be the same as in e2e.yml
+
+on:
+  pull_request:
+    paths-ignore: # This expression needs to match the paths ignored on e2e.yml.
+      - '**'
+      - '!*.md'
+      - '!*.asciidoc'
+      - '!docs/**'
+
+permissions:
+  contents: read
+
+## Concurrency only allowed in the main branch.
+## So old builds running for old commits within the same Pull Request are cancelled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # dummy steps that allow to bypass those mandatory checks for tests
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required for docs"'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,8 @@ env:
   # keep_serverless-staging-oblt OR keep_serverless-qa-oblt
   SERVERLESS_PROJECT: serverless-production-oblt
 
+# NOTE: if you add a new job and it's a mandatory check then
+#       update e2e-docs.yml
 jobs:
   test:
     if: |


### PR DESCRIPTION
For any mandatory GitHub checks that use the `paths-ignore`, then there should be a parity one in the `docs` workflows.