### PR TITLE
Short circuit WritingTask and await its completion in dispose(async)

### DIFF
--- a/src/Elastic.OpenTelemetry/Diagnostics/LogFileWriter.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LogFileWriter.cs
@@ -13,7 +13,7 @@ internal sealed class LogFileWriter : IDisposable, IAsyncDisposable
 	public static readonly bool FileLoggingEnabled = IsFileLoggingEnabled();
 
 	private bool _disposing;
-	private ManualResetEventSlim _syncDisposeWaitHandle = new(false);
+	private readonly ManualResetEventSlim _syncDisposeWaitHandle = new(false);
 	private readonly StreamWriter _streamWriter;
 	private readonly Channel<string> _channel = Channel.CreateBounded<string>(new BoundedChannelOptions(1024)
 	{


### PR DESCRIPTION
This to ensure there is no ongoing IO when _streamWriter disposes:

```
  Error: System.InvalidOperationException : The stream is currently in use by a previous operation on the stream.

    Failed Elastic.OpenTelemetry.Tests.TransactionIdProcessorTests.TransactionId_IsAddedToTags [564 ms]
    Error Message:
     System.InvalidOperationException : The stream is currently in use by a previous operation on the stream.
    Stack Trace:
       at System.IO.StreamWriter.ThrowAsyncIOInProgress()
     at System.IO.StreamWriter.Dispose(Boolean disposing)
     at System.IO.TextWriter.Dispose()
     at Elastic.OpenTelemetry.Diagnostics.LogFileWriter.Dispose() in /home/runner/work/elastic-otel-dotnet/elastic-otel-dotnet/src/Elastic.OpenTelemetry/Diagnostics/LogFileWriter.cs:line 297
     at Elastic.OpenTelemetry.AgentBuilder.Agent.Dispose() in /home/runner/work/elastic-otel-dotnet/elastic-otel-dotnet/src/Elastic.OpenTelemetry/AgentBuilder.cs:line 270
     at Elastic.OpenTelemetry.Tests.TransactionIdProcessorTests.TransactionId_IsAddedToTags() in /home/runner/work/elastic-otel-dotnet/elastic-otel-dotnet/tests/Elastic.OpenTelemetry.Tests/TransactionIdProcessorTests.cs:line 36
     at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
     at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

this was highlighted on our CI test runs:

https://github.com/elastic/elastic-otel-dotnet/actions/runs/8020502607/job/21910481682?pr=39
