### PR TITLE
action: support provenance with GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - provenance
 
 permissions:
   contents: read


### PR DESCRIPTION
### What

- Enable Provenance with GitHub
- Support release workflow run in `main` but:
  - skip push to nuget
  - skip slack notifications
  - skip post-release steps

### Why

Provenance can be enabled from the very beginning in this project

Test the release branch before the release.

### Test

See https://github.com/elastic/elastic-otel-dotnet/actions/runs/8436326632/job/23103571576?pr=66 that produced the attestation https://github.com/elastic/elastic-otel-dotnet/attestations. (NOTE: artifacts were not uploaded)