### PR TITLE
Fix `release-main` action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/elastic/index.json"
           dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source "github"
-          dotnet nuget add source github
+          dotnet nuget remove source github
       
       # Github packages requires authentication, this is likely going away in the future so for now we publish to feedz.io
       - name: Publish canary packages to feedz.io

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,19 +28,21 @@ jobs:
       - run: ./build.sh release --test-suite=skip-e2e
         name: Release
 
-      - name: generate build provenance
+      - name: Generate build provenance
         uses: github-early-access/generate-build-provenance@main
         with:
           subject-path: "${{ github.workspace }}/${{ env.RELEASE_PACKAGES }}"
 
-      - name: publish canary packages github package repository
+      - name: Publish canary packages github package repository
         shell: bash
         # this is a best effort to push to GHPR, we've observed it being unavailable intermittently
         continue-on-error: true
-        run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols
+        run: |
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/elastic/index.json"
+          dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source "github"
+          dotnet nuget add source github
       
       # Github packages requires authentication, this is likely going away in the future so for now we publish to feedz.io
-      - run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{secrets.FEEDZ_IO_API_KEY}} -s https://f.feedz.io/elastic/all/nuget/index.json --skip-duplicate --no-symbols
-        name: publish canary packages to feedz.io
-        if: false && github.event_name == 'push' && startswith(github.ref, 'refs/heads')
-
+      - name: Publish canary packages to feedz.io
+        run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{ secrets.FEEDZ_IO_API_KEY }} -s https://f.feedz.io/elastic/all/nuget/index.json --skip-duplicate --no-symbols
+        if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -37,12 +37,9 @@ jobs:
         shell: bash
         # this is a best effort to push to GHPR, we've observed it being unavailable intermittently
         continue-on-error: true
-        run: |
-          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/elastic/index.json"
-          dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source "github"
-          dotnet nuget remove source github
+        run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/elastic/index.json" --skip-duplicate --no-symbols 
       
       # Github packages requires authentication, this is likely going away in the future so for now we publish to feedz.io
       - name: Publish canary packages to feedz.io
-        run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{ secrets.FEEDZ_IO_API_KEY }} -s https://f.feedz.io/elastic/all/nuget/index.json --skip-duplicate --no-symbols
+        run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{ secrets.FEEDZ_IO_API_KEY }} --source https://f.feedz.io/elastic/all/nuget/index.json --skip-duplicate --no-symbols
         if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     - run: ./build.sh release --test-suite=skip-all
       name: Release
 
-    - name: generate build provenance
+    - name: Generate build provenance
       uses: github-early-access/generate-build-provenance@main
       with:
         subject-path: "${{ github.workspace }}/${{ env.RELEASE_PACKAGES }}"
@@ -49,7 +49,7 @@ jobs:
 
     - name: Release to Nuget (only for release events)
       if: ${{ github.event_name == 'release' }}
-      run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${REPO_API_KEY} -s  ${REPO_API_URL} --skip-duplicate --no-symbols
+      run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${REPO_API_KEY} --source ${REPO_API_URL} --skip-duplicate --no-symbols
 
     - if: ${{ success() && github.event_name == 'release' }}
       uses: elastic/apm-pipeline-library/.github/actions/slack-message@current

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
- Adds the missing source for the push to the GH package repo. 
- Re-enables Feeds.io (unless we intended to leave that skipped @Mpdreamz). 
- Captitalises the first word in step names.