### PR TITLE
Add ElasticCompatibilityProcessor

### DIFF
--- a/examples/Example.MinimalApi/appsettings.json
+++ b/examples/Example.MinimalApi/appsettings.json
@@ -2,11 +2,11 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Elastic.OpenTelemetry": "Information"
     }
   },
   "AllowedHosts": "*",
-  "ServiceName": "elastic-minimal-api-example",
   "AspNetCoreInstrumentation": {
     "RecordException": "true"
   }

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
@@ -10,11 +10,21 @@ namespace Elastic.OpenTelemetry.Diagnostics;
 
 internal static partial class LoggerMessages
 {
+#pragma warning disable SYSLIB1006 // Multiple logging methods cannot use the same event id within a class
+	// We explictly reuse the same event ID and this is the same log message, but with different types for the structured data
+
 	[LoggerMessage(EventId = 100, Level = LogLevel.Trace, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void FoundTag(this ILogger logger, string processorName, string attributeName, string attributeValue);
 
+	[LoggerMessage(EventId = 100, Level = LogLevel.Trace, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	internal static partial void FoundTag(this ILogger logger, string processorName, string attributeName, int attributeValue);
+
 	[LoggerMessage(EventId = 101, Level = LogLevel.Trace, Message = "{ProcessorName} set `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void SetTag(this ILogger logger, string processorName, string attributeName, string attributeValue);
+
+	[LoggerMessage(EventId = 101, Level = LogLevel.Trace, Message = "{ProcessorName} set `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	internal static partial void SetTag(this ILogger logger, string processorName, string attributeName, int attributeValue);
+#pragma warning restore SYSLIB1006 // Multiple logging methods cannot use the same event id within a class
 
 	[LoggerMessage(EventId = 20, Level = LogLevel.Trace, Message = "Added '{ProcessorTypeName}' processor to '{BuilderTypeName}'.")]
 	public static partial void LogProcessorAdded(this ILogger logger, string processorTypeName, string builderTypeName);

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
@@ -4,15 +4,17 @@
 
 using System.Diagnostics;
 using Elastic.OpenTelemetry.Diagnostics.Logging;
-using Elastic.OpenTelemetry.Processors;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.OpenTelemetry.Diagnostics;
 
 internal static partial class LoggerMessages
 {
-	[LoggerMessage(EventId = 100, Level = LogLevel.Trace, Message = $"{nameof(TransactionIdProcessor)} added 'transaction.id' tag to Activity.")]
-	internal static partial void TransactionIdProcessorTagAdded(this ILogger logger);
+	[LoggerMessage(EventId = 100, Level = LogLevel.Trace, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	internal static partial void FoundTag(this ILogger logger, string processorName, string attributeName, string attributeValue);
+
+	[LoggerMessage(EventId = 101, Level = LogLevel.Trace, Message = "{ProcessorName} set `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	internal static partial void SetTag(this ILogger logger, string processorName, string attributeName, string attributeValue);
 
 	[LoggerMessage(EventId = 20, Level = LogLevel.Trace, Message = "Added '{ProcessorTypeName}' processor to '{BuilderTypeName}'.")]
 	public static partial void LogProcessorAdded(this ILogger logger, string processorTypeName, string builderTypeName);

--- a/src/Elastic.OpenTelemetry/Diagnostics/Logging/LogState.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/Logging/LogState.cs
@@ -10,6 +10,7 @@ namespace Elastic.OpenTelemetry.Diagnostics.Logging;
 internal class LogState : IReadOnlyList<KeyValuePair<string, object?>>
 {
 	private readonly Activity? _activity;
+
 	public Activity? Activity
 	{
 		get => _activity;
@@ -44,7 +45,7 @@ internal class LogState : IReadOnlyList<KeyValuePair<string, object?>>
 		init => _spanId = value;
 	}
 
-	private readonly List<KeyValuePair<string, object?>> _values = new();
+	private readonly List<KeyValuePair<string, object?>> _values = [];
 
 	public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => _values.GetEnumerator();
 

--- a/src/Elastic.OpenTelemetry/ElasticOpenTelemetryBuilder.cs
+++ b/src/Elastic.OpenTelemetry/ElasticOpenTelemetryBuilder.cs
@@ -86,6 +86,7 @@ public class ElasticOpenTelemetryBuilder : IOpenTelemetryBuilder
 			logging.IncludeScopes = true;
 			//TODO add processor that adds service.id
 		});
+
 		openTelemetry
 			.WithLogging(logging =>
 			{

--- a/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
@@ -20,8 +20,14 @@ public static class TracerProviderBuilderExtensions
 	/// <summary>
 	/// Include Elastic trace processors to ensure data is enriched and extended.
 	/// </summary>
-	public static TracerProviderBuilder AddElasticProcessors(this TracerProviderBuilder builder, ILogger? logger = null) =>
-		builder.LogAndAddProcessor(new TransactionIdProcessor(logger ?? NullLogger.Instance), logger ?? NullLogger.Instance);
+	public static TracerProviderBuilder AddElasticProcessors(this TracerProviderBuilder builder, ILogger? logger = null)
+	{
+		logger ??= NullLogger.Instance;
+
+		return builder
+			.LogAndAddProcessor(new TransactionIdProcessor(logger), logger)
+			.LogAndAddProcessor(new ElasticCompatibilityProcessor(logger), logger);
+	}
 
 	private static TracerProviderBuilder LogAndAddProcessor(this TracerProviderBuilder builder, BaseProcessor<Activity> processor, ILogger logger)
 	{

--- a/src/Elastic.OpenTelemetry/Processors/ElasticCompatibilityProcessor.cs
+++ b/src/Elastic.OpenTelemetry/Processors/ElasticCompatibilityProcessor.cs
@@ -1,0 +1,112 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics;
+using Elastic.OpenTelemetry.Diagnostics;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using static Elastic.OpenTelemetry.SemanticConventions.TraceSemanticConventions;
+
+namespace Elastic.OpenTelemetry.Processors;
+
+/// <summary>
+/// This processor ensures that the data is compatible with Elastic backends.
+/// <para>
+/// It checks for the presence of the older semantic conventions and if they are not present, it will
+/// add them. This is only necessary for compatibility with older versions of the intake OTel endpoints
+/// on Elastic APM. These issues will be fixed centrally in future versions of the intake code.
+/// </para>
+/// </summary>
+/// <param name="logger"></param>
+public class ElasticCompatibilityProcessor(ILogger logger) : BaseProcessor<Activity>
+{
+	private readonly ILogger _logger = logger;
+
+	/// <inheritdoc />
+	public override void OnEnd(Activity activity)
+	{
+		if (activity.Kind == ActivityKind.Server)
+		{
+			string? httpScheme = null;
+			string? httpTarget = null;
+			string? urlScheme = null;
+			string? urlPath = null;
+			string? urlQuery = null;
+			string? netHostName = null;
+			string? netHostPort = null;
+			string? serverAddress = null;
+			string? serverPort = null;
+
+			// We loop once, collecting all the attributes we need for the older and newer
+			// semantic conventions. This is a bit more verbose but ensures we don't iterate
+			// the tags multiple times.
+			foreach (var tag in activity.TagObjects)
+			{
+				if (tag.Key == HttpScheme)
+					httpScheme = ProcessStringAttribute(tag);
+
+				if (tag.Key == HttpTarget)
+					httpTarget = ProcessStringAttribute(tag);
+
+				if (tag.Key == UrlScheme)
+					urlScheme = ProcessStringAttribute(tag);
+
+				if (tag.Key == UrlPath)
+					urlPath = ProcessStringAttribute(tag);
+
+				if (tag.Key == UrlQuery)
+					urlQuery = ProcessStringAttribute(tag);
+
+				if (tag.Key == NetHostName)
+					netHostName = ProcessStringAttribute(tag);
+
+				if (tag.Key == ServerAddress)
+					serverAddress = ProcessStringAttribute(tag);
+
+				if (tag.Key == NetHostPort)
+					netHostPort = ProcessStringAttribute(tag);
+
+				if (tag.Key == ServerPort)
+					serverPort = ProcessStringAttribute(tag);
+			}
+
+			// Set the older semantic convention attributes
+			if (httpScheme is null && urlScheme is not null)
+				SetAttribute(HttpScheme, urlScheme);
+
+			if (httpTarget is null && urlPath is not null)
+			{
+				var target = urlPath;
+
+				if (urlQuery is not null)
+					target += $"?{urlQuery}";
+
+				SetAttribute(HttpTarget, target);
+			}
+
+			if (netHostName is null && serverAddress is not null)
+				SetAttribute(NetHostName, serverAddress);
+
+			if (netHostPort is null && serverPort is not null)
+				SetAttribute(NetHostPort, serverPort);
+		}
+
+		string? ProcessStringAttribute(KeyValuePair<string, object?> tag)
+		{
+			if (tag.Value is string value)
+			{
+				_logger.FoundTag(nameof(ElasticCompatibilityProcessor), tag.Key, value);
+				return value;
+			}
+
+			return null;
+		}
+
+		void SetAttribute(string attributeName, string value)
+		{
+			_logger.SetTag(nameof(ElasticCompatibilityProcessor), attributeName, value);
+			activity.SetTag(attributeName, value);
+		}
+	}
+}

--- a/src/Elastic.OpenTelemetry/Processors/TransactionIdProcessor.cs
+++ b/src/Elastic.OpenTelemetry/Processors/TransactionIdProcessor.cs
@@ -1,6 +1,7 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
 using System.Diagnostics;
 using Elastic.OpenTelemetry.Diagnostics;
 using Microsoft.Extensions.Logging;
@@ -30,6 +31,6 @@ public sealed class TransactionIdProcessor(ILogger logger) : BaseProcessor<Activ
 			return;
 
 		activity.SetTag(TransactionIdTagName, _currentTransactionId.Value.Value.ToString());
-		logger.TransactionIdProcessorTagAdded();
+		logger.SetTag(nameof(TransactionIdProcessor), TransactionIdTagName, _currentTransactionId.Value.Value.ToString());
 	}
 }

--- a/src/Elastic.OpenTelemetry/SemanticConventions/TraceSemanticConventions.cs
+++ b/src/Elastic.OpenTelemetry/SemanticConventions/TraceSemanticConventions.cs
@@ -1,0 +1,25 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.OpenTelemetry.SemanticConventions;
+
+internal static class TraceSemanticConventions
+{
+	// HTTP
+	public const string HttpScheme = "http.scheme";
+	public const string HttpTarget = "http.target";
+
+	// NET
+	public const string NetHostName = "net.host.name";
+	public const string NetHostPort = "net.host.port";
+
+	// SERVER
+	public const string ServerAddress = "server.address";
+	public const string ServerPort = "server.port";
+
+	// URL
+	public const string UrlPath = "url.path";
+	public const string UrlQuery = "url.query";
+	public const string UrlScheme = "url.scheme";
+}

--- a/tests/Elastic.OpenTelemetry.EndToEndTests/README.md
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/README.md
@@ -8,8 +8,8 @@ Requires an already running serverless observability project on cloud.
 The configuration can be provided either as asp.net secrets or environment variables.
 
 ```bash
-dotnet user-secrets set "E2E:Endpoint" "<url>" --project tests/Elastic.OpenTelemetry.IntegrationTests
-dotnet user-secrets set "E2E:Authorization" "<header>" --project tests/Elastic.OpenTelemetry.IntegrationTests
+dotnet user-secrets set "E2E:Endpoint" "<url>" --project tests/Elastic.OpenTelemetry.EndToEndTests
+dotnet user-secrets set "E2E:Authorization" "<header>" --project tests/Elastic.OpenTelemetry.EndToEndTests
 ```
 
 The equivalent environment variables are `E2E__ENDPOINT` and `E2E__AUTHORIZATION`. For local development setting 
@@ -38,8 +38,8 @@ Once invited and accepted the invited email can be used to login during the auto
 These can be provided again as user secrets:
 
 ```bash
-dotnet user-secrets set "E2E:BrowserEmail" "<email>" --project tests/Elastic.OpenTelemetry.IntegrationTests
-dotnet user-secrets set "E2E:BrowserPassword" "<password>" --project tests/Elastic.OpenTelemetry.IntegrationTests
+dotnet user-secrets set "E2E:BrowserEmail" "<email>" --project tests/Elastic.OpenTelemetry.EndToEndTests
+dotnet user-secrets set "E2E:BrowserPassword" "<password>" --project tests/Elastic.OpenTelemetry.EndToEndTests
 ```
 
 or environment variables (`E2E__BROWSEREMAIL` and `E2E__BROWSERPASSWORD`).

--- a/tests/Elastic.OpenTelemetry.Tests/Processors/ElasticCompatibilityProcessorTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Processors/ElasticCompatibilityProcessorTests.cs
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.OpenTelemetry.SemanticConventions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.OpenTelemetry.Tests.Processors;
+
+public sealed class ElasticCompatibilityProcessorTests : IDisposable
+{
+	private readonly ActivitySource _activitySource;
+	private readonly ActivityListener _listener;
+
+	public ElasticCompatibilityProcessorTests()
+	{
+		// It's a bit annoying as we have to create an ActivitySource and ActivityListener
+		// just so we can create an Activity with the ActivityKind set. The Activity ctor
+		// doesn't allow us to set the ActivityKind directly.
+		_activitySource = new ActivitySource("test");
+
+		// We need a listener so that CreateActivity returns a non-null Activity
+		_listener = new ActivityListener()
+		{
+			ShouldListenTo = _ => true,
+			Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+		};
+
+		ActivitySource.AddActivityListener(_listener);
+	}
+
+	[Fact]
+	public void AddsExpectedNetHostAttributes()
+	{
+		const string hostName = "/";
+		const int port = 80;
+
+		var activity = _activitySource.CreateActivity("test", ActivityKind.Server)!;
+
+		activity.SetTag(TraceSemanticConventions.ServerAddress, hostName);
+		activity.SetTag(TraceSemanticConventions.ServerPort, port);
+
+		var sut = new ElasticCompatibilityProcessor(NullLogger.Instance);
+		sut.OnEnd(activity);
+
+		// We can test with Tags (rather than TagObjects) here as we know these are string values
+		activity.Tags.Single(t => t.Key == TraceSemanticConventions.NetHostName).Value.Should().Be(hostName);
+
+		activity.TagObjects.Single(t => t.Key == TraceSemanticConventions.NetHostPort).Value
+			.Should().BeOfType<int>().Subject.Should().Be(port);
+	}
+
+	[Fact]
+	public void AddsExpectedHttpAttributes_WhenUrlQuery_IsNotPresent()
+	{
+		const string scheme = "https";
+		const string path = "/my/path";
+
+		var activity = _activitySource.CreateActivity("test", ActivityKind.Server)!;
+
+		activity.SetTag(TraceSemanticConventions.UrlScheme, scheme);
+		activity.SetTag(TraceSemanticConventions.UrlPath, path);
+
+		var sut = new ElasticCompatibilityProcessor(NullLogger.Instance);
+		sut.OnEnd(activity);
+
+		// We can test with Tags (rather than TagObjects) here as we know these are string values
+		activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpScheme).Value.Should().Be(scheme);
+		activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpTarget).Value.Should().Be(path);
+	}
+
+	[Fact]
+	public void AddsExpectedHttpAttributes_WhenUrlQuery_IsPresent()
+	{
+		const string scheme = "https";
+		const string path = "/my/path";
+		const string query = "q=OpenTelemetry";
+
+		var activity = _activitySource.CreateActivity("test", ActivityKind.Server)!;
+
+		activity.SetTag(TraceSemanticConventions.UrlScheme, scheme);
+		activity.SetTag(TraceSemanticConventions.UrlPath, path);
+		activity.SetTag(TraceSemanticConventions.UrlQuery, query);
+
+		var sut = new ElasticCompatibilityProcessor(NullLogger.Instance);
+		sut.OnEnd(activity);
+
+		// We can test with Tags (rather than TagObjects) here as we know these are string values
+		activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpScheme).Value.Should().Be(scheme);
+		activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpTarget).Value.Should().Be($"{path}?{query}");
+	}
+
+	public void Dispose()
+	{
+		_activitySource.Dispose();
+		_listener.Dispose();
+	}
+}


### PR DESCRIPTION
Fixes #80

The `ElasticCompatibilityProcessor` is used to apply legacy semantic conventions that may be missing on spans for applications which apply the latest conventions. This can cause UI issues in some cases since intake relies on the legacy attributes to map data to the Elastic format. That will be fixed in [apm-data](https://github.com/elastic/apm-data). Introducing this processor provides a more rapid solution for consumers until the intake mapping is updated.