### PR TITLE
Update formatting

### DIFF
--- a/build/scripts/CommandLine.fs
+++ b/build/scripts/CommandLine.fs
@@ -23,13 +23,16 @@ type Build =
     
     | [<CliPrefix(CliPrefix.None);SubCommand>] Unit_Test
     | [<CliPrefix(CliPrefix.None);SubCommand>] End_To_End
+
+    | [<CliPrefix(CliPrefix.None);SubCommand>] Format
     
-    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] PristineCheck 
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] CheckFormat
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] PristineCheck
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] GeneratePackages
-    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] ValidateLicenses 
-    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] ValidatePackages 
-    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] GenerateReleaseNotes 
-    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] GenerateApiChanges 
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] ValidateLicenses
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] ValidatePackages
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] GenerateReleaseNotes
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] GenerateApiChanges
     | [<CliPrefix(CliPrefix.None);SubCommand>] Release
     
     | [<Inherit;AltCommandLine("-s")>] Single_Target
@@ -49,12 +52,14 @@ with
             | End_To_End -> "alias to providing: test --test-suite=e2e"
             | Test -> "runs a clean build and then runs all the tests unless --test-suite is provided"
             | Release -> "runs build, tests, and create and validates the packages shy of publishing them"
+            | Format -> "runs dotnet format"
             
             // steps
-            | PristineCheck  
+            | CheckFormat
+            | PristineCheck
             | GeneratePackages
             | ValidateLicenses
-            | ValidatePackages 
+            | ValidatePackages
             | GenerateReleaseNotes
             | GenerateApiChanges -> "Undocumented, dependent target"
             

--- a/src/Elastic.OpenTelemetry/Diagnostics/Logging/AgentLoggingHelpers.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/Logging/AgentLoggingHelpers.cs
@@ -20,7 +20,7 @@ internal static class AgentLoggingHelpers
 
 		if (string.IsNullOrEmpty(logLevelEnvironmentVariable))
 			return defaultLogLevel;
-		
+
 		var parsedLogLevel = LogLevelHelpers.ToLogLevel(logLevelEnvironmentVariable);
 		return parsedLogLevel != LogLevel.None ? parsedLogLevel : defaultLogLevel;
 	}

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggingEventListener.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggingEventListener.cs
@@ -5,9 +5,9 @@
 using System.Diagnostics.Tracing;
 using System.Text;
 using System.Text.RegularExpressions;
+using Elastic.OpenTelemetry.Configuration;
 using Elastic.OpenTelemetry.Diagnostics.Logging;
 using Microsoft.Extensions.Logging;
-using Elastic.OpenTelemetry.Configuration;
 
 namespace Elastic.OpenTelemetry.Diagnostics;
 


### PR DESCRIPTION
This allows the running of the dotnet format via the build script. During builds, `checkFormat` is also run without the full pristine check.

Note: The `exit_code_of` doesn't seem to work as expected right now. Instead of getting the matched output for the result, the actual error is less clean and doesn't explain the problem. This was already an issue (but is not a showstopper), so I've ignored it for now as I'm not confident I know the best solution.

Example of the "bad" output.
```
:: clean: Succeeded (2.21 s)
:: checkformat: Starting...
C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Diagnostics\Logging\AgentLoggingHelpers.cs(1,63): error WHITESPACE: Fix whitespace formatting. Replace 2 characters with '\r\n'. [C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj]
C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Diagnostics\Logging\AgentLoggingHelpers.cs(2,77): error WHITESPACE: Fix whitespace formatting. Replace 2 characters with '\r\n'. [C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj]
C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Diagnostics\Logging\AgentLoggingHelpers.cs(3,65): error WHITESPACE: Fix whitespace formatting. Replace 4 characters with '\r\n\r\n'. [C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj]
C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Diagnostics\Logging\AgentLoggingHelpers.cs(23,1): error WHITESPACE: Fix whitespace formatting. Replace 6 characters with '\r\n\t\t'. [C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj]
C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Diagnostics\LoggingEventListener.cs(1,1): error IMPORTS: Fix imports ordering. [C:\Users\SteveGordon\Code\Elastic\elastic-otel-dotnet\src\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj]
:: checkformat: FAILED! Process exited with '2' "dotnet format --verify-no-changes --verbosity quiet" (18.98 s)
:: ──────────────────────────────────────
:: Target       Outcome    Duration
:: ───────────  ─────────  ──────────────
:: version      Succeeded  1.15 s   5.1%
:: clean        Succeeded  2.21 s   9.9%
:: checkformat  FAILED!    18.98 s  85.0%
:: ──────────────────────────────────────
```