### PR TITLE
Enhance resource attributes

### DIFF
--- a/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
+++ b/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0;net8.0</TargetFrameworks>
     <Title>Elastic OpenTelemetry .NET Distribution</Title>
-    <Description>OpenTelemetry extensions for Elastic Observability, fully native with zero code changes</Description>
+    <Description>OpenTelemetry extensions for Elastic Observability, fully native with zero code changes.</Description>
     <PackageTags>elastic;opentelemetry;observabillity;apm;logs;metrics;traces;monitoring</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />

--- a/src/Elastic.OpenTelemetry/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/ResourceBuilderExtensions.cs
@@ -1,14 +1,82 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
-using Elastic.OpenTelemetry.SemanticConventions;
 
+using System.Diagnostics;
+using Elastic.OpenTelemetry.SemanticConventions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.ResourceDetectors.Host;
 using OpenTelemetry.Resources;
 
 namespace Elastic.OpenTelemetry.Extensions;
 
-internal static class ResourceBuilderExtensions
+/// <summary>
+/// Extension methods for <see cref="ResourceBuilder"/>.
+/// </summary>
+public static class ResourceBuilderExtensions
 {
+	private static readonly string InstanceId = Guid.NewGuid().ToString();
+
+	/// <summary>
+	/// For advanced scenarios, where the all Elastic defaults are not disabled (essentially using the "vanilla" OpenTelemetry SDK),
+	/// this method can be used to add Elastic resource defaults to the <see cref="ResourceBuilder"/>.
+	/// </summary>
+	/// <remarks>
+	/// After clearing the <see cref="ResourceBuilder"/> the following are added in order:
+	/// <list type="bullet">
+	/// <item>A default, fallback <c>service.name</c>.</item>
+	/// <item>A default, unqiue <c>service.instance.id</c>.</item>
+	/// <item>The telemetry SDK attributes via <c>AddTelemetrySdk()</c>.</item>
+	/// <item>The Elastic telemetry distro attributes.</item>
+	/// <item>Adds resource attributes parsed from OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME environment variables
+	/// via <c>AddEnvironmentVariableDetector()</c>.</item>
+	/// <item>Host attributes, <c>host.name</c> and <c>host.id</c> (on supported targets).</item>
+	/// </list>
+	/// <para>These mostly mirror what the vanilla SDK does, but allow us to ensure that certain resources attributes that the
+	/// Elastic APM backend requires to drive the UIs are present in some form. Any of these may be overridden by further
+	/// resource configuration.</para>
+	/// </remarks>
+	/// <param name="builder">A <see cref="ResourceBuilder"/> that will be configured with Elastic defaults.</param>
+	/// <returns>The <see cref="ResourceBuilder"/> for chaining calls.</returns>
+	public static ResourceBuilder AddElasticResourceDefaults(this ResourceBuilder builder) =>
+		builder.AddElasticResourceDefaults(NullLogger.Instance);
+
+	internal static ResourceBuilder AddElasticResourceDefaults(this ResourceBuilder builder, ILogger logger)
+	{
+		var defaultServiceName = "unknown_service";
+
+		try
+		{
+			var processName = Process.GetCurrentProcess().ProcessName;
+			if (!string.IsNullOrWhiteSpace(processName))
+			{
+				defaultServiceName = $"{defaultServiceName}:{processName}";
+			}
+		}
+		catch
+		{
+			// GetCurrentProcess can throw PlatformNotSupportedException
+		}
+
+		builder
+			.Clear()
+			.AddAttributes(new Dictionary<string, object>
+			{
+				{ ResourceSemanticConventions.AttributeServiceName, defaultServiceName },
+				{ ResourceSemanticConventions.AttributeServiceInstanceId, InstanceId }
+			})
+			.AddTelemetrySdk()
+			.AddDistroAttributes()
+			.AddEnvironmentVariableDetector();
+
+#if NET462_OR_GREATER || NET6_0_OR_GREATER
+		builder.AddDetector(new HostDetector(logger));
+#endif
+
+		return builder;
+	}
+
 	internal static ResourceBuilder AddDistroAttributes(this ResourceBuilder builder) =>
 		builder.AddAttributes(new Dictionary<string, object>
 		{

--- a/src/Elastic.OpenTelemetry/Resources/HostDetector.cs
+++ b/src/Elastic.OpenTelemetry/Resources/HostDetector.cs
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Modified from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/44c8576ef1290d9fbb6fbbdc973ae1b344afb4c2/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+// As the host.id is support not yet released, we are using the code from the contrib project directly for now.
+
+// TODO - Switch to the contrib package once the features we need are released.
+
+using System.Diagnostics;
+using System.Text;
+using Elastic.OpenTelemetry.SemanticConventions;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Resources;
+#if NETFRAMEWORK || NET6_0_OR_GREATER
+using Microsoft.Win32;
+#endif
+
+namespace OpenTelemetry.ResourceDetectors.Host;
+
+/// <summary>
+/// Host detector.
+/// </summary>
+internal sealed class HostDetector : IResourceDetector
+{
+	private const string ETCMACHINEID = "/etc/machine-id";
+	private const string ETCVARDBUSMACHINEID = "/var/lib/dbus/machine-id";
+
+	private readonly PlatformID _platformId;
+	private readonly Func<IEnumerable<string>> _getFilePaths;
+	private readonly Func<string?> _getMacOsMachineId;
+	private readonly Func<string?> _getWindowsMachineId;
+
+	private readonly ILogger _logger;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="HostDetector"/> class.
+	/// </summary>
+	internal HostDetector(ILogger logger)
+	{
+		_platformId = Environment.OSVersion.Platform;
+		_getFilePaths = GetFilePaths;
+		_getMacOsMachineId = GetMachineIdMacOs;
+		_getWindowsMachineId = GetMachineIdWindows;
+		_logger = logger;
+	}
+
+	/// <summary>
+	/// Detects the resource attributes from host.
+	/// </summary>
+	/// <returns>Resource with key-value pairs of resource attributes.</returns>
+	public Resource Detect()
+	{
+		try
+		{
+			var attributes = new List<KeyValuePair<string, object>>(2)
+			{
+				new(ResourceSemanticConventions.AttributeHostName, Environment.MachineName),
+			};
+			var machineId = GetMachineId();
+
+			if (machineId != null && !string.IsNullOrEmpty(machineId))
+			{
+				attributes.Add(new(ResourceSemanticConventions.AttributeHostId, machineId));
+			}
+
+			return new Resource(attributes);
+		}
+		catch (InvalidOperationException ex)
+		{
+			// Handling InvalidOperationException due to https://learn.microsoft.com/en-us/dotnet/api/system.environment.machinename#exceptions
+			_logger.LogError("Failed to detect host resource due to {Exception}", ex);
+		}
+
+		return Resource.Empty;
+	}
+
+	internal static string? ParseMacOsOutput(string? output)
+	{
+		if (output == null || string.IsNullOrEmpty(output))
+		{
+			return null;
+		}
+
+		var lines = output.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+
+		foreach (var line in lines)
+		{
+#if NETFRAMEWORK
+            if (line.IndexOf("IOPlatformUUID", StringComparison.OrdinalIgnoreCase) >= 0)
+#else
+			if (line.Contains("IOPlatformUUID", StringComparison.OrdinalIgnoreCase))
+#endif
+			{
+				var parts = line.Split('"');
+
+				if (parts.Length > 3)
+				{
+					return parts[3];
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static IEnumerable<string> GetFilePaths()
+	{
+		yield return ETCMACHINEID;
+		yield return ETCVARDBUSMACHINEID;
+	}
+
+	private string? GetMachineIdMacOs()
+	{
+		try
+		{
+			var startInfo = new ProcessStartInfo
+			{
+				FileName = "sh",
+				Arguments = "ioreg -rd1 -c IOPlatformExpertDevice",
+				UseShellExecute = false,
+				CreateNoWindow = true,
+				RedirectStandardOutput = true,
+			};
+
+			var sb = new StringBuilder();
+			using var process = Process.Start(startInfo);
+			process?.WaitForExit();
+			sb.Append(process?.StandardOutput.ReadToEnd());
+			return sb.ToString();
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError("Failed to get machine ID on MacOS due to {Exception}", ex);
+		}
+
+		return null;
+	}
+
+#pragma warning disable CA1416
+	// stylecop wants this protected by System.OperatingSystem.IsWindows
+	// this type only exists in .NET 5+
+	private string? GetMachineIdWindows()
+	{
+#if NETFRAMEWORK || NET6_0_OR_GREATER
+		try
+		{
+			using var subKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography", false);
+			return subKey?.GetValue("MachineGuid") as string ?? null;
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError("Failed to get machine ID on Windows due to {Exception}", ex);
+		}
+#endif
+
+		return null;
+	}
+#pragma warning restore CA1416
+
+	private string? GetMachineId() => _platformId switch
+	{
+		PlatformID.Unix => GetMachineIdLinux(),
+		PlatformID.MacOSX => ParseMacOsOutput(_getMacOsMachineId()),
+		PlatformID.Win32NT => _getWindowsMachineId(),
+		_ => null,
+	};
+
+	private string? GetMachineIdLinux()
+	{
+		var paths = _getFilePaths();
+
+		foreach (var path in paths)
+		{
+			if (File.Exists(path))
+			{
+				try
+				{
+					return File.ReadAllText(path).Trim();
+				}
+				catch (Exception ex)
+				{
+					_logger.LogError("Failed to get machine ID on Linux due to {Exception}", ex);
+				}
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/Elastic.OpenTelemetry/Resources/HostDetector.cs
+++ b/src/Elastic.OpenTelemetry/Resources/HostDetector.cs
@@ -90,7 +90,7 @@ internal sealed class HostDetector : IResourceDetector
 		foreach (var line in lines)
 		{
 #if NETFRAMEWORK
-            if (line.IndexOf("IOPlatformUUID", StringComparison.OrdinalIgnoreCase) >= 0)
+			if (line.IndexOf("IOPlatformUUID", StringComparison.OrdinalIgnoreCase) >= 0)
 #else
 			if (line.Contains("IOPlatformUUID", StringComparison.OrdinalIgnoreCase))
 #endif

--- a/src/Elastic.OpenTelemetry/Resources/HostDetector.cs
+++ b/src/Elastic.OpenTelemetry/Resources/HostDetector.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/src/Elastic.OpenTelemetry/SemanticConventions/ResourceSemanticConventions.cs
+++ b/src/Elastic.OpenTelemetry/SemanticConventions/ResourceSemanticConventions.cs
@@ -7,4 +7,10 @@ internal static class ResourceSemanticConventions
 {
 	public const string AttributeTelemetryDistroName = "telemetry.distro.name";
 	public const string AttributeTelemetryDistroVersion = "telemetry.distro.version";
+
+	public const string AttributeServiceName = "service.name";
+	public const string AttributeServiceInstanceId = "service.instance.id";
+
+	public const string AttributeHostName = "host.name";
+	public const string AttributeHostId = "host.id";
 }

--- a/tests/Elastic.OpenTelemetry.Tests/Resources/ResourceAttributeTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Resources/ResourceAttributeTests.cs
@@ -1,0 +1,126 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.OpenTelemetry.Configuration;
+using Elastic.OpenTelemetry.Extensions;
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using Xunit.Abstractions;
+
+namespace Elastic.OpenTelemetry.Tests.Resources;
+
+public sealed class ResourceAttributeTests : IDisposable
+{
+	private const string OtelResourceAttributes = "OTEL_RESOURCE_ATTRIBUTES";
+
+	private readonly string? _originalOtelResourceAttributesEnvVar = Environment.GetEnvironmentVariable(OtelResourceAttributes);
+
+	private readonly ElasticOpenTelemetryBuilderOptions _options;
+
+	public ResourceAttributeTests(ITestOutputHelper output) =>
+		_options = new ElasticOpenTelemetryBuilderOptions()
+		{
+			Logger = new TestLogger(output),
+			DistroOptions = new ElasticOpenTelemetryOptions() { SkipOtlpExporter = true }
+		};
+
+	[Fact]
+	public void DefaultServiceResourceAttributesAreAdded()
+	{
+		var exportedItems = new List<Activity>(0);
+		var exporter = new InMemoryExporter<Activity>(exportedItems);
+
+		using var session = new ElasticOpenTelemetryBuilder(_options)
+			.WithTracing(tpb => tpb.AddProcessor(new SimpleActivityExportProcessor(exporter)))
+			.Build();
+
+		var resource = exporter.ParentProvider.GetResource();
+
+		resource.Attributes.Should().ContainSingle(a => a.Key == "service.name")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Which.Should().StartWith("unknown_service:");
+
+		var instanceId = resource.Attributes.Should().ContainSingle(a => a.Key == "service.instance.id")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Subject;
+
+		Guid.TryParseExact(instanceId, "D", out _).Should().BeTrue(); // The distro should set a GUID for the instance ID if not configured by the user
+	}
+
+	[Fact]
+	public void UserProvidedConfigureResourceValues_ShouldOverrideDefaults()
+	{
+		const string serviceName = "Test";
+		const string serviceVersion = "1.0.0";
+		const string serviceInstanceId = "FromConfigureResource";
+
+		var exportedItems = new List<Activity>(0);
+		var exporter = new InMemoryExporter<Activity>(exportedItems);
+
+		using var session = new ElasticOpenTelemetryBuilder(_options)
+			.WithTracing(tpb => tpb
+				.ConfigureResource(rb => rb.AddService(serviceName, serviceVersion: serviceVersion, serviceInstanceId: serviceInstanceId))
+				.AddProcessor(new SimpleActivityExportProcessor(exporter)))
+			.Build();
+
+		var resource = exporter.ParentProvider.GetResource();
+
+		resource.Attributes.Should().ContainSingle(a => a.Key == "service.name")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Which.Should().Be(serviceName);
+
+		resource.Attributes.Should().ContainSingle(a => a.Key == "service.version")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Which.Should().Be(serviceVersion);
+
+		resource.Attributes.Should().ContainSingle(a => a.Key == "service.instance.id")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Which.Should().Be(serviceInstanceId);
+	}
+
+	[Fact]
+	public void UserProvided_ResourceEnvironmentVariable_ShouldOverrideDefaults()
+	{
+		const string serviceName = "service-from-env-var";
+		const string serviceInstanceId = "instance-from-env-var";
+
+		Environment.SetEnvironmentVariable(OtelResourceAttributes, $"service.name={serviceName},service.instance.id={serviceInstanceId}");
+
+		var exportedItems = new List<Activity>(0);
+		var exporter = new InMemoryExporter<Activity>(exportedItems);
+
+		using var session = new ElasticOpenTelemetryBuilder(_options)
+			.WithTracing(tpb => tpb.AddProcessor(new SimpleActivityExportProcessor(exporter)))
+			.Build();
+
+		var resource = exporter.ParentProvider.GetResource();
+
+		resource.Attributes.Should().ContainSingle(a => a.Key == "service.name")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Which.Should().Be(serviceName);
+
+		resource.Attributes.Should().ContainSingle(a => a.Key == "service.instance.id")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Which.Should().Be(serviceInstanceId);
+
+		ResetEnvironmentVariables();
+	}
+
+	[Fact]
+	public void DefaultHostResourceAttributesAreAdded()
+	{
+		var exportedItems = new List<Activity>(0);
+		var exporter = new InMemoryExporter<Activity>(exportedItems);
+
+		using var session = new ElasticOpenTelemetryBuilder(_options)
+			.WithTracing(tpb => tpb.AddProcessor(new SimpleActivityExportProcessor(exporter)))
+			.Build();
+
+		var resource = exporter.ParentProvider.GetResource();
+
+		resource.Attributes.Should().ContainSingle(a => a.Key == "host.name")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Which.Should().NotBeEmpty();
+
+		resource.Attributes.Should().ContainSingle(a => a.Key == "host.id")
+			.Subject.Value.Should().NotBeNull().And.BeAssignableTo<string>().Which.Should().NotBeEmpty();
+	}
+
+	private void ResetEnvironmentVariables() =>
+		Environment.SetEnvironmentVariable(OtelResourceAttributes, _originalOtelResourceAttributesEnvVar);
+
+	public void Dispose() => ResetEnvironmentVariables();
+}

--- a/tests/Elastic.OpenTelemetry.Tests/TransactionIdProcessorTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/TransactionIdProcessorTests.cs
@@ -11,10 +11,12 @@ namespace Elastic.OpenTelemetry.Tests;
 
 public class TransactionIdProcessorTests(ITestOutputHelper output)
 {
+	private readonly ITestOutputHelper _output = output;
+
 	[Fact]
 	public void TransactionId_IsAddedToTags()
 	{
-		var options = new ElasticOpenTelemetryBuilderOptions { Logger = new TestLogger(output), DistroOptions = new ElasticOpenTelemetryOptions() { SkipOtlpExporter = true } };
+		var options = new ElasticOpenTelemetryBuilderOptions { Logger = new TestLogger(_output), DistroOptions = new ElasticOpenTelemetryOptions() { SkipOtlpExporter = true } };
 		const string activitySourceName = nameof(TransactionId_IsAddedToTags);
 
 		var activitySource = new ActivitySource(activitySourceName, "1.0.0");


### PR DESCRIPTION
With this PR, we ensure that we always add a `service.instance.id` if not configured by the user. This is required since we likely want to use this in the dashboard, and the SDK does not always set it. It only gets set when `AddService` is used and not, for example, if a service name is provided via an environment variable.

This also adds a `HostDetector`, which is modified from the [one in the contrib repo](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/44c8576ef1290d9fbb6fbbdc973ae1b344afb4c2/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs). The `host.id` detection is not yet in a released alpha package. I propose we include this code in our distro until that package is more mature and includes the `host.id`.