### PR TITLE
Fix E2E tests on CI

### DIFF
--- a/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/ApmUIBrowserContext.cs
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/ApmUIBrowserContext.cs
@@ -94,6 +94,13 @@ public class ApmUIBrowserContext : IAsyncLifetime
 		var servicesHeader = page.GetByRole(AriaRole.Heading, new() { Name = "Services" });
 		await servicesHeader.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeout });
 
+		//service.name : dotnet-e2e-*
+		var queryBar = page.GetByRole(AriaRole.Textbox, new() { Name = "Start typing to search and filter the APM page" });
+		await queryBar.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeout });
+
+		await queryBar.FillAsync(_serviceName);
+		await queryBar.PressAsync("Enter");
+
 		Exception? observed = null;
 
 		var refreshTimeout = (float)TimeSpan.FromSeconds(5).TotalMilliseconds;

--- a/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/DotNetRunApplication.cs
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/DotNetRunApplication.cs
@@ -83,7 +83,7 @@ public abstract class DotNetRunApplication
 				if (processIdMatch.Success)
 					ProcessId = int.Parse(processIdMatch.Groups["processid"].Value);
 
-				return l.Line.StartsWith("      Application started.");
+				return l.Line.Contains("Application started.");
 			}
 		};
 	}


### PR DESCRIPTION
This fixes the E2E tests to filter for our servicename prior to selecting it in the service overview.

We have a lot of new neighbors on the shared serverless project now 😸 