### PR TITLE
github-action: skip e2e-testing for dependabot

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,9 +31,8 @@ env:
 #       update e2e-docs.yml
 jobs:
   test:
-    if: |
-      github.event_name != 'pull_request' || 
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
+    if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
added the actor condition

This has been already tested in other places, see https://github.com/elastic/apm-agent-java/blob/b1a41729f43377b8cfbed387753ebe4bcc0b405a/.github/workflows/main.yml#L338