### PR TITLE
Use new oblt-cli actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,19 +42,12 @@ jobs:
         id: bootstrap
         uses: ./.github/workflows/bootstrap
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: elastic/oblt-actions/google/auth@v1.6.0
 
-      - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-cluster-credentials@current
+      - uses: elastic/oblt-actions/oblt-cli/cluster-credentials@v1.6.0
         with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-          cluster-name: ${{ env.SERVERLESS_PROJECT }}
-          vault-url: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          cluster-name:  ${{ env.SERVERLESS_PROJECT }}
 
       - name: Get the browser email and password from Vault
         uses: hashicorp/vault-action@v3.0.0


### PR DESCRIPTION
Migrate to new oblt-cli actions to use the latest oblt-cli version that needs GCP to access cluster secrets