### PR TITLE
Update logging envs and defaulting mechanism

### DIFF
--- a/examples/Example.MinimalApi/appsettings.json
+++ b/examples/Example.MinimalApi/appsettings.json
@@ -12,8 +12,8 @@
   },
   "Elastic": {
     "OpenTelemetry": {
-      "FileLogDirectory": "C:\\Logs\\OtelDistro",
-      "FileLogLevel": "Information"
+      "LogDirectory": "C:\\Logs\\OtelDistro",
+      "LogLevel": "Information"
     }
   }
 }

--- a/src/Elastic.OpenTelemetry/Configuration/ElasticOpenTelemetryOptions.cs
+++ b/src/Elastic.OpenTelemetry/Configuration/ElasticOpenTelemetryOptions.cs
@@ -78,7 +78,8 @@ public class ElasticOpenTelemetryOptions
 	internal ElasticOpenTelemetryOptions(IConfiguration? configuration, IDictionary? environmentVariables = null)
 		: this(environmentVariables)
 	{
-		if (configuration is null) return;
+		if (configuration is null)
+			return;
 		SetFromConfiguration(configuration, LogDirectoryConfigPropertyName, ref _logDirectory, ref _logDirectorySource, StringParser);
 		SetFromConfiguration(configuration, LogLevelConfigPropertyName, ref _logLevel, ref _logLevelSource, LogLevelParser);
 		SetFromConfiguration(configuration, LogTargetsConfigPropertyName, ref _logTargets, ref _logTargetsSource, LogTargetsParser);
@@ -139,7 +140,7 @@ public class ElasticOpenTelemetryOptions
 	/// <para> - /var/log/elastic/apm-agent-dotnet (on Linux)</para>
 	/// <para> - ~/Library/Application_Support/elastic/apm-agent-dotnet (on OSX)</para>
 	/// </summary>
-	public string LogDirectoryDefault => _defaultLogDirectory ;
+	public string LogDirectoryDefault => _defaultLogDirectory;
 
 	/// <summary>
 	/// The output directory where the Elastic distribution of OpenTelemetry will write log files.

--- a/src/Elastic.OpenTelemetry/Configuration/ElasticOpenTelemetryOptions.cs
+++ b/src/Elastic.OpenTelemetry/Configuration/ElasticOpenTelemetryOptions.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections;
 using System.Runtime.InteropServices;
 using Elastic.OpenTelemetry.Diagnostics.Logging;
 using Microsoft.Extensions.Configuration;
@@ -26,36 +27,46 @@ namespace Elastic.OpenTelemetry.Configuration;
 public class ElasticOpenTelemetryOptions
 {
 	private static readonly string ConfigurationSection = "Elastic:OpenTelemetry";
-	private static readonly string FileLogDirectoryConfigPropertyName = "FileLogDirectory";
-	private static readonly string FileLogLevelConfigPropertyName = "FileLogLevel";
+	private static readonly string LogDirectoryConfigPropertyName = "LogDirectory";
+	private static readonly string LogLevelConfigPropertyName = "LogLevel";
+	private static readonly string LogTargetsConfigPropertyName = "LogTargets";
 	private static readonly string SkipOtlpExporterConfigPropertyName = "SkipOtlpExporter";
 	private static readonly string EnabledElasticDefaultsConfigPropertyName = "EnabledElasticDefaults";
 
 	// For a relatively limited number of properties, this is okay. If this grows significantly, consider a
 	// more flexible approach similar to the layered configuration used in the Elastic APM Agent.
 	private EnabledElasticDefaults? _elasticDefaults;
-	private string? _fileLogDirectory;
-	private ConfigSource _fileLogDirectorySource = ConfigSource.Default;
-	private LogLevel? _fileLogLevel;
-	private ConfigSource _fileLogLevelSource = ConfigSource.Default;
-	private bool? _skipOtlpExporter;
-	private ConfigSource _skipOtlpExporterSource = ConfigSource.Default;
-	private string? _enabledElasticDefaults;
-	private ConfigSource _enabledElasticDefaultsSource = ConfigSource.Default;
+
+	private string? _logDirectory;
+	private ConfigSource _logDirectorySource = ConfigSource.Default;
+
+	private LogLevel? _logLevel;
+	private ConfigSource _logLevelSource = ConfigSource.Default;
+
+	private LogTargets? _logTargets;
+	private ConfigSource _logTargetsSource = ConfigSource.Default;
+
+	private readonly bool? _skipOtlpExporter;
+	private readonly ConfigSource _skipOtlpExporterSource = ConfigSource.Default;
+
+	private readonly string? _enabledElasticDefaults;
+	private readonly ConfigSource _enabledElasticDefaultsSource = ConfigSource.Default;
 
 	private string? _loggingSectionLogLevel;
-
 	private readonly string _defaultLogDirectory;
+	private readonly IDictionary _environmentVariables;
 
 	/// <summary>
 	/// Creates a new instance of <see cref="ElasticOpenTelemetryOptions"/> with properties
 	/// bound from environment variables.
 	/// </summary>
-	public ElasticOpenTelemetryOptions()
+	public ElasticOpenTelemetryOptions(IDictionary? environmentVariables = null)
 	{
 		_defaultLogDirectory = GetDefaultLogDirectory();
-		SetFromEnvironment(ELASTIC_OTEL_LOG_DIRECTORY, ref _fileLogDirectory, ref _fileLogDirectorySource, StringParser);
-		SetFromEnvironment(ELASTIC_OTEL_LOG_LEVEL, ref _fileLogLevel, ref _fileLogLevelSource, LogLevelParser);
+		_environmentVariables = environmentVariables ?? Environment.GetEnvironmentVariables();
+		SetFromEnvironment(ELASTIC_OTEL_LOG_DIRECTORY, ref _logDirectory, ref _logDirectorySource, StringParser);
+		SetFromEnvironment(ELASTIC_OTEL_LOG_LEVEL, ref _logLevel, ref _logLevelSource, LogLevelParser);
+		SetFromEnvironment(ELASTIC_OTEL_LOG_TARGETS, ref _logTargets, ref _logTargetsSource, LogTargetsParser);
 		SetFromEnvironment(ELASTIC_OTEL_SKIP_OTLP_EXPORTER, ref _skipOtlpExporter, ref _skipOtlpExporterSource, BoolParser);
 		SetFromEnvironment(ELASTIC_OTEL_ENABLE_ELASTIC_DEFAULTS, ref _enabledElasticDefaults, ref _enabledElasticDefaultsSource, StringParser);
 	}
@@ -64,11 +75,13 @@ public class ElasticOpenTelemetryOptions
 	/// Creates a new instance of <see cref="ElasticOpenTelemetryOptions"/> with properties
 	/// bound from environment variables and an <see cref="IConfiguration"/> instance.
 	/// </summary>
-	internal ElasticOpenTelemetryOptions(IConfiguration? configuration) : this()
+	internal ElasticOpenTelemetryOptions(IConfiguration? configuration, IDictionary? environmentVariables = null)
+		: this(environmentVariables)
 	{
 		if (configuration is null) return;
-		SetFromConfiguration(configuration, FileLogDirectoryConfigPropertyName, ref _fileLogDirectory, ref _fileLogDirectorySource, StringParser);
-		SetFromConfiguration(configuration, FileLogLevelConfigPropertyName, ref _fileLogLevel, ref _fileLogLevelSource, LogLevelParser);
+		SetFromConfiguration(configuration, LogDirectoryConfigPropertyName, ref _logDirectory, ref _logDirectorySource, StringParser);
+		SetFromConfiguration(configuration, LogLevelConfigPropertyName, ref _logLevel, ref _logLevelSource, LogLevelParser);
+		SetFromConfiguration(configuration, LogTargetsConfigPropertyName, ref _logTargets, ref _logTargetsSource, LogTargetsParser);
 		SetFromConfiguration(configuration, SkipOtlpExporterConfigPropertyName, ref _skipOtlpExporter, ref _skipOtlpExporterSource, BoolParser);
 		SetFromConfiguration(configuration, EnabledElasticDefaultsConfigPropertyName, ref _enabledElasticDefaults, ref _enabledElasticDefaultsSource, StringParser);
 
@@ -84,11 +97,31 @@ public class ElasticOpenTelemetryOptions
 			if (string.IsNullOrEmpty(_loggingSectionLogLevel))
 				_loggingSectionLogLevel = config.GetValue<string>("Logging:LogLevel:Default");
 
-			if (!string.IsNullOrEmpty(_loggingSectionLogLevel) && _fileLogLevel is null)
+			if (!string.IsNullOrEmpty(_loggingSectionLogLevel) && _logLevel is null)
 			{
-				_fileLogLevel = LogLevelHelpers.ToLogLevel(_loggingSectionLogLevel);
-				_fileLogLevelSource = ConfigSource.IConfiguration;
+				_logLevel = LogLevelHelpers.ToLogLevel(_loggingSectionLogLevel);
+				_logLevelSource = ConfigSource.IConfiguration;
 			}
+		}
+	}
+
+	/// <summary>
+	/// Calculates whether global logging is enabled based on
+	/// <see cref="LogTargets"/>, <see cref="LogDirectory"/> and <see cref="LogLevel"/>
+	/// </summary>
+	public bool GlobalLogEnabled
+	{
+		get
+		{
+			var isActive = (_logLevel.HasValue || !string.IsNullOrWhiteSpace(_logDirectory) || _logTargets.HasValue);
+			if (isActive)
+			{
+				if (_logLevel is LogLevel.None)
+					isActive = false;
+				else if (_logTargets is LogTargets.None)
+					isActive = false;
+			}
+			return isActive;
 		}
 	}
 
@@ -106,7 +139,7 @@ public class ElasticOpenTelemetryOptions
 	/// <para> - /var/log/elastic/apm-agent-dotnet (on Linux)</para>
 	/// <para> - ~/Library/Application_Support/elastic/apm-agent-dotnet (on OSX)</para>
 	/// </summary>
-	public string FileLogDirectoryDefault => _defaultLogDirectory;
+	public string LogDirectoryDefault => _defaultLogDirectory ;
 
 	/// <summary>
 	/// The output directory where the Elastic distribution of OpenTelemetry will write log files.
@@ -116,13 +149,13 @@ public class ElasticOpenTelemetryOptions
 	/// <c>{ProcessName}_{UtcUnixTimeMilliseconds}_{ProcessId}.instrumentation.log</c>.
 	/// This log file includes log messages from the OpenTelemetry SDK and the Elastic distribution.
 	/// </remarks>
-	public string? FileLogDirectory
+	public string LogDirectory
 	{
-		get => _fileLogDirectory;
+		get => _logDirectory ?? LogDirectoryDefault;
 		init
 		{
-			_fileLogDirectory = value;
-			_fileLogDirectorySource = ConfigSource.Property;
+			_logDirectory = value;
+			_logDirectorySource = ConfigSource.Property;
 		}
 	}
 
@@ -141,13 +174,24 @@ public class ElasticOpenTelemetryOptions
 	/// <item><term>Trace</term><description>Contain the most detailed messages.</description></item>
 	/// </list>
 	/// </remarks>
-	public LogLevel? FileLogLevel
+	public LogLevel LogLevel
 	{
-		get => _fileLogLevel;
+		get => _logLevel ?? LogLevel.Warning;
 		init
 		{
-			_fileLogLevel = value;
-			_fileLogLevelSource = ConfigSource.Property;
+			_logLevel = value;
+			_logLevelSource = ConfigSource.Property;
+		}
+	}
+
+	/// <inheritdoc cref="LogTargets"/>>
+	public LogTargets LogTargets
+	{
+		get => _logTargets ?? (GlobalLogEnabled ? LogTargets.File : LogTargets.None);
+		init
+		{
+			_logTargets = value;
+			_logTargetsSource = ConfigSource.Property;
 		}
 	}
 
@@ -194,13 +238,42 @@ public class ElasticOpenTelemetryOptions
 	private static (bool, LogLevel?) LogLevelParser(string? s) =>
 		!string.IsNullOrEmpty(s) ? (true, LogLevelHelpers.ToLogLevel(s)) : (false, null);
 
+	private static (bool, LogTargets?) LogTargetsParser(string? s)
+	{
+		//var tokens = s?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries });
+		if (string.IsNullOrWhiteSpace(s))
+			return (false, null);
+
+		var logTargets = LogTargets.None;
+		var found = false;
+
+		foreach (var target in s.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+		{
+			if (IsSet(target, "stdout"))
+				logTargets |= LogTargets.StdOut;
+			else if (IsSet(target, "file"))
+				logTargets |= LogTargets.File;
+			else if (IsSet(target, "none"))
+				logTargets |= LogTargets.None;
+		}
+		return !found ? (false, null) : (true, logTargets);
+
+		bool IsSet(string k, string v)
+		{
+			var b = k.Trim().Equals(v, StringComparison.InvariantCultureIgnoreCase);
+			if (b)
+				found = true;
+			return b;
+		}
+	}
+
 	private static (bool, string) StringParser(string? s) => !string.IsNullOrEmpty(s) ? (true, s) : (false, string.Empty);
 
 	private static (bool, bool?) BoolParser(string? s) => bool.TryParse(s, out var boolValue) ? (true, boolValue) : (false, null);
 
-	private static void SetFromEnvironment<T>(string key, ref T field, ref ConfigSource configSourceField, Func<string?, (bool, T)> parser)
+	private void SetFromEnvironment<T>(string key, ref T field, ref ConfigSource configSourceField, Func<string?, (bool, T)> parser)
 	{
-		var (success, value) = parser(Environment.GetEnvironmentVariable(key));
+		var (success, value) = parser(GetSafeEnvironmentVariable(key));
 
 		if (success)
 		{
@@ -264,13 +337,20 @@ public class ElasticOpenTelemetryOptions
 		static EnabledElasticDefaults All() => EnabledElasticDefaults.Tracing | EnabledElasticDefaults.Metrics | EnabledElasticDefaults.Logging;
 	}
 
+	private string GetSafeEnvironmentVariable(string key)
+	{
+		var value = _environmentVariables.Contains(key) ? _environmentVariables[key]?.ToString() : null;
+		return value ?? string.Empty;
+	}
+
+
 	internal void LogConfigSources(ILogger logger)
 	{
-		logger.LogInformation("Configured value for {ConfigKey}: '{ConfigValue}' from [{ConfigSource}]", FileLogDirectoryConfigPropertyName,
-			_fileLogDirectory, _fileLogDirectorySource);
+		logger.LogInformation("Configured value for {ConfigKey}: '{ConfigValue}' from [{ConfigSource}]", LogDirectoryConfigPropertyName,
+			_logDirectory, _logDirectorySource);
 
-		logger.LogInformation("Configured value for {ConfigKey}: '{ConfigValue}' from [{ConfigSource}]", FileLogLevelConfigPropertyName,
-			_fileLogLevel, _fileLogLevelSource);
+		logger.LogInformation("Configured value for {ConfigKey}: '{ConfigValue}' from [{ConfigSource}]", LogLevelConfigPropertyName,
+			_logLevel, _logLevelSource);
 
 		logger.LogInformation("Configured value for {ConfigKey}: '{ConfigValue}' from [{ConfigSource}]", SkipOtlpExporterConfigPropertyName,
 			_skipOtlpExporter, _skipOtlpExporterSource);

--- a/src/Elastic.OpenTelemetry/Configuration/EnvironmentVariables.cs
+++ b/src/Elastic.OpenTelemetry/Configuration/EnvironmentVariables.cs
@@ -11,6 +11,7 @@ internal static class EnvironmentVariables
 
 	public const string ELASTIC_OTEL_LOG_DIRECTORY = nameof(ELASTIC_OTEL_LOG_DIRECTORY);
 	public const string ELASTIC_OTEL_LOG_LEVEL = nameof(ELASTIC_OTEL_LOG_LEVEL);
+	public const string ELASTIC_OTEL_LOG_TARGETS = nameof(ELASTIC_OTEL_LOG_TARGETS);
 
 	public const string ELASTIC_OTEL_ENABLE_ELASTIC_DEFAULTS = nameof(ELASTIC_OTEL_ENABLE_ELASTIC_DEFAULTS);
 	// ReSharper enable InconsistentNaming

--- a/src/Elastic.OpenTelemetry/Configuration/EnvironmentVariables.cs
+++ b/src/Elastic.OpenTelemetry/Configuration/EnvironmentVariables.cs
@@ -6,8 +6,12 @@ namespace Elastic.OpenTelemetry.Configuration;
 
 internal static class EnvironmentVariables
 {
-	public const string ElasticOtelSkipOtlpExporter = "ELASTIC_OTEL_SKIP_OTLP_EXPORTER";
-	public const string ElasticOtelFileLogDirectoryEnvironmentVariable = "ELASTIC_OTEL_FILE_LOG_DIRECTORY";
-	public const string ElasticOtelFileLogLevelEnvironmentVariable = "ELASTIC_OTEL_FILE_LOG_LEVEL";
-	public const string ElasticOtelEnableElasticDefaults = "ELASTIC_OTEL_ENABLE_ELASTIC_DEFAULTS";
+	// ReSharper disable InconsistentNaming
+	public const string ELASTIC_OTEL_SKIP_OTLP_EXPORTER = nameof(ELASTIC_OTEL_SKIP_OTLP_EXPORTER);
+
+	public const string ELASTIC_OTEL_LOG_DIRECTORY = nameof(ELASTIC_OTEL_LOG_DIRECTORY);
+	public const string ELASTIC_OTEL_LOG_LEVEL = nameof(ELASTIC_OTEL_LOG_LEVEL);
+
+	public const string ELASTIC_OTEL_ENABLE_ELASTIC_DEFAULTS = nameof(ELASTIC_OTEL_ENABLE_ELASTIC_DEFAULTS);
+	// ReSharper enable InconsistentNaming
 }

--- a/src/Elastic.OpenTelemetry/Configuration/LogTargets.cs
+++ b/src/Elastic.OpenTelemetry/Configuration/LogTargets.cs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.OpenTelemetry.Configuration;
+
+/// <summary>
+/// Control how the distribution should globally log.
+/// </summary>
+[Flags]
+public enum LogTargets
+{
+
+	/// <summary>No global logging </summary>
+	None,
+	/// <summary>
+	/// Enable file logging. Use <see cref="ElasticOpenTelemetryOptions.LogLevel"/>
+	/// and <see cref="ElasticOpenTelemetryOptions.LogDirectoryDefault"/> to set any values other than the defaults
+	/// </summary>
+	File = 1 << 0, //1
+	/// <summary>
+	/// Write to standard out, useful in scenarios where file logging might not be an option or harder to set up.
+	/// <para>e.g. containers, k8s, etc.</para>
+	/// </summary>
+	StdOut = 1 << 1, //2
+}

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
@@ -66,8 +66,8 @@ internal static partial class LoggerMessages
 
 		string[] environmentVariables =
 		[
-			EnvironmentVariables.ElasticOtelFileLogDirectoryEnvironmentVariable,
-			EnvironmentVariables.ElasticOtelFileLogLevelEnvironmentVariable
+			EnvironmentVariables.ELASTIC_OTEL_LOG_DIRECTORY,
+			EnvironmentVariables.ELASTIC_OTEL_LOG_LEVEL
 		];
 
 		foreach (var variable in environmentVariables)

--- a/src/Elastic.OpenTelemetry/Diagnostics/Logging/AgentLoggingHelpers.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/Logging/AgentLoggingHelpers.cs
@@ -3,28 +3,12 @@
 // See the LICENSE file in the project root for more information
 
 using System.Diagnostics;
-using Elastic.OpenTelemetry.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.OpenTelemetry.Diagnostics.Logging;
 
 internal static class AgentLoggingHelpers
 {
-	public static LogLevel DefaultLogLevel => LogLevel.Information;
-
-	public static LogLevel GetElasticOtelLogLevelFromEnvironmentVariables()
-	{
-		var defaultLogLevel = DefaultLogLevel;
-
-		var logLevelEnvironmentVariable = Environment.GetEnvironmentVariable(EnvironmentVariables.ELASTIC_OTEL_LOG_LEVEL);
-
-		if (string.IsNullOrEmpty(logLevelEnvironmentVariable))
-			return defaultLogLevel;
-
-		var parsedLogLevel = LogLevelHelpers.ToLogLevel(logLevelEnvironmentVariable);
-		return parsedLogLevel != LogLevel.None ? parsedLogLevel : defaultLogLevel;
-	}
-
 	public static void WriteLogLine(this ILogger logger, Activity? activity, int managedThreadId, DateTime dateTime, LogLevel logLevel, string logLine, string? spanId)
 	{
 		var state = new LogState

--- a/src/Elastic.OpenTelemetry/Diagnostics/Logging/AgentLoggingHelpers.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/Logging/AgentLoggingHelpers.cs
@@ -16,7 +16,7 @@ internal static class AgentLoggingHelpers
 	{
 		var defaultLogLevel = DefaultLogLevel;
 
-		var logLevelEnvironmentVariable = Environment.GetEnvironmentVariable(EnvironmentVariables.ElasticOtelFileLogLevelEnvironmentVariable);
+		var logLevelEnvironmentVariable = Environment.GetEnvironmentVariable(EnvironmentVariables.ELASTIC_OTEL_LOG_LEVEL);
 
 		if (string.IsNullOrEmpty(logLevelEnvironmentVariable))
 			return defaultLogLevel;

--- a/src/Elastic.OpenTelemetry/Diagnostics/Logging/FileLogger.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/Logging/FileLogger.cs
@@ -32,18 +32,17 @@ internal sealed class FileLogger : IDisposable, IAsyncDisposable, ILogger
 	public FileLogger(ElasticOpenTelemetryOptions options)
 	{
 		_scopeProvider = new LoggerExternalScopeProvider();
+		_configuredLogLevel = options.LogLevel;
+		FileLoggingEnabled = options.GlobalLogEnabled;
 
-		var logDirectory = options.FileLogDirectory;
-		var logLevel = options.FileLogLevel;
-		if (logLevel == LogLevel.None || (logLevel == null && logDirectory == null))
+		if (!FileLoggingEnabled)
 			return;
-
-		_configuredLogLevel = logLevel ?? LogLevel.Information;
-		logDirectory ??= options.FileLogDirectoryDefault;
 
 		var process = Process.GetCurrentProcess();
 		// When ordered by filename, we get see logs from the same process grouped, then ordered by oldest to newest, then the PID for that instance
 		var logFileName = $"{process.ProcessName}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}_{process.Id}.instrumentation.log";
+
+		var logDirectory = options.LogDirectory;
 		LogFilePath = Path.Combine(logDirectory, logFileName);
 
 		if (!Directory.Exists(logDirectory))

--- a/src/Elastic.OpenTelemetry/Diagnostics/Logging/FileLogger.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/Logging/FileLogger.cs
@@ -33,30 +33,21 @@ internal sealed class FileLogger : IDisposable, IAsyncDisposable, ILogger
 	{
 		_scopeProvider = new LoggerExternalScopeProvider();
 
-		var configuredPath = options.FileLogDirectory ?? Environment.GetEnvironmentVariable(EnvironmentVariables.ElasticOtelFileLogDirectoryEnvironmentVariable);
-
-		if (string.IsNullOrEmpty(configuredPath))
+		var logDirectory = options.FileLogDirectory;
+		var logLevel = options.FileLogLevel;
+		if (logLevel == LogLevel.None || (logLevel == null && logDirectory == null))
 			return;
 
-		if (!string.IsNullOrEmpty(options.FileLogLevel))
-		{
-			var logLevel = LogLevelHelpers.ToLogLevel(options.FileLogLevel);
-
-			if (logLevel != LogLevel.None)
-				_configuredLogLevel = logLevel;
-		}
-		else
-		{
-			_configuredLogLevel = AgentLoggingHelpers.GetElasticOtelLogLevelFromEnvironmentVariables();
-		}
+		_configuredLogLevel = logLevel ?? LogLevel.Information;
+		logDirectory ??= options.FileLogDirectoryDefault;
 
 		var process = Process.GetCurrentProcess();
-
 		// When ordered by filename, we get see logs from the same process grouped, then ordered by oldest to newest, then the PID for that instance
-		LogFilePath = Path.Combine(configuredPath, $"{process.ProcessName}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}_{process.Id}.instrumentation.log");
+		var logFileName = $"{process.ProcessName}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}_{process.Id}.instrumentation.log";
+		LogFilePath = Path.Combine(logDirectory, logFileName);
 
-		if (!Directory.Exists(configuredPath))
-			Directory.CreateDirectory(configuredPath);
+		if (!Directory.Exists(logDirectory))
+			Directory.CreateDirectory(logDirectory);
 
 		//StreamWriter.Dispose disposes underlying stream too
 		var stream = new FileStream(LogFilePath, FileMode.OpenOrCreate, FileAccess.Write);

--- a/src/Elastic.OpenTelemetry/Diagnostics/Logging/LogLevelHelpers.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/Logging/LogLevelHelpers.cs
@@ -16,32 +16,27 @@ internal static class LogLevelHelpers
 	public const string Trace = "Trace";
 	public const string None = "None";
 
-	public static LogLevel ToLogLevel(string logLevelString)
+	public static LogLevel? ToLogLevel(string logLevelString)
 	{
-		var logLevel = LogLevel.None;
-
 		if (logLevelString.Equals(Trace, StringComparison.OrdinalIgnoreCase))
-			logLevel = LogLevel.Trace;
-
-		else if (logLevelString.Equals(Debug, StringComparison.OrdinalIgnoreCase))
-			logLevel = LogLevel.Debug;
-
-		else if (logLevelString.Equals(Information, StringComparison.OrdinalIgnoreCase))
-			logLevel = LogLevel.Information;
-
-		else if (logLevelString.Equals(Information, StringComparison.OrdinalIgnoreCase))
-			logLevel = LogLevel.Information;
-
-		else if (logLevelString.Equals(Warning, StringComparison.OrdinalIgnoreCase))
-			logLevel = LogLevel.Warning;
-
-		else if (logLevelString.Equals(Error, StringComparison.OrdinalIgnoreCase))
-			logLevel = LogLevel.Error;
-
-		else if (logLevelString.Equals(Critical, StringComparison.OrdinalIgnoreCase))
-			logLevel = LogLevel.Critical;
-
-		return logLevel;
+			return LogLevel.Trace;
+		if (logLevelString.Equals(Debug, StringComparison.OrdinalIgnoreCase))
+			return LogLevel.Debug;
+		if (logLevelString.Equals("Info", StringComparison.OrdinalIgnoreCase))
+			return LogLevel.Information;
+		if (logLevelString.Equals(Information, StringComparison.OrdinalIgnoreCase))
+			return LogLevel.Information;
+		if (logLevelString.Equals("Warn", StringComparison.OrdinalIgnoreCase))
+			return LogLevel.Warning;
+		if (logLevelString.Equals(Warning, StringComparison.OrdinalIgnoreCase))
+			return LogLevel.Warning;
+		if (logLevelString.Equals(Error, StringComparison.OrdinalIgnoreCase))
+			return LogLevel.Error;
+		if (logLevelString.Equals(Critical, StringComparison.OrdinalIgnoreCase))
+			return LogLevel.Critical;
+		if (logLevelString.Equals(None, StringComparison.OrdinalIgnoreCase))
+			return LogLevel.None;
+		return null;
 	}
 
 	public static string AsString(this LogLevel logLevel) =>

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggingEventListener.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggingEventListener.cs
@@ -36,9 +36,9 @@ internal sealed
 		_logger = logger;
 
 		// When both a file log level and a logging section log level are provided, the more verbose of the two is used.
-		// This insures we subscribes to the lowest level of events needed.
+		// This insures we subscribe to the lowest level of events needed.
 		// The specific loggers will then determine	if they should log the event based on their own log level.
-		var eventLevel = LogLevelHelpers.ToLogLevel(options.FileLogLevel);
+		var eventLevel = options.FileLogLevel;
 		if (!string.IsNullOrEmpty(options.LoggingSectionLogLevel))
 		{
 			var logLevel = LogLevelHelpers.ToLogLevel(options.LoggingSectionLogLevel);

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggingEventListener.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggingEventListener.cs
@@ -38,10 +38,10 @@ internal sealed
 		// When both a file log level and a logging section log level are provided, the more verbose of the two is used.
 		// This insures we subscribe to the lowest level of events needed.
 		// The specific loggers will then determine	if they should log the event based on their own log level.
-		var eventLevel = options.FileLogLevel;
+		var eventLevel = options.LogLevel;
 		if (!string.IsNullOrEmpty(options.LoggingSectionLogLevel))
 		{
-			var logLevel = LogLevelHelpers.ToLogLevel(options.LoggingSectionLogLevel);
+			var logLevel = LogLevelHelpers.ToLogLevel(options.LoggingSectionLogLevel) ?? LogLevel.None;
 
 			if (logLevel < eventLevel)
 				eventLevel = logLevel;

--- a/tests/Elastic.OpenTelemetry.Tests/Configuration/ElasticOpenTelemetryOptionsTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Configuration/ElasticOpenTelemetryOptionsTests.cs
@@ -227,7 +227,8 @@ public sealed class ElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 		sut.LogConfigSources(logger);
 
 		logger.Messages.Count.Should().Be(4);
-		foreach (var message in logger.Messages) message.Should().EndWith("from [IConfiguration]");
+		foreach (var message in logger.Messages)
+			message.Should().EndWith("from [IConfiguration]");
 	}
 
 	[Fact]

--- a/tests/Elastic.OpenTelemetry.Tests/Configuration/GlobalLogConfigurationTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Configuration/GlobalLogConfigurationTests.cs
@@ -1,0 +1,147 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections;
+using Elastic.OpenTelemetry.Configuration;
+using Microsoft.Extensions.Logging;
+using static Elastic.OpenTelemetry.Configuration.EnvironmentVariables;
+
+namespace Elastic.OpenTelemetry.Tests.Configuration;
+
+public class GlobalLogConfigurationTests
+{
+	[Fact]
+	public void Check_Defaults()
+	{
+		var config = new ElasticOpenTelemetryOptions(new Hashtable());
+		config.GlobalLogEnabled.Should().BeFalse();
+		config.LogLevel.Should().Be(LogLevel.Warning);
+		config.LogDirectory.Should().Be(config.LogDirectoryDefault);
+		config.LogTargets.Should().Be(LogTargets.None);
+	}
+
+	//
+	[Theory]
+	[InlineData(ELASTIC_OTEL_LOG_LEVEL, "Info")]
+	[InlineData(ELASTIC_OTEL_LOG_DIRECTORY, "1")]
+	//only if explicitly specified to 'none' should we not default to file logging.
+	[InlineData(ELASTIC_OTEL_LOG_TARGETS, "file")]
+	public void CheckActivation(string environmentVariable, string value)
+	{
+		var config = new ElasticOpenTelemetryOptions(new Hashtable { { environmentVariable, value } });
+		config.GlobalLogEnabled.Should().BeTrue();
+		config.LogTargets.Should().Be(LogTargets.File);
+	}
+
+	//
+	[Theory]
+	[InlineData(ELASTIC_OTEL_LOG_LEVEL, "none")]
+	//only if explicitly specified to 'none' should we not default to file logging.
+	[InlineData(ELASTIC_OTEL_LOG_TARGETS, "none")]
+	public void CheckDeactivation(string environmentVariable, string value)
+	{
+		var config = new ElasticOpenTelemetryOptions(new Hashtable
+		{
+			{ ELASTIC_OTEL_LOG_DIRECTORY, "" },
+			{ environmentVariable, value }
+		});
+		config.GlobalLogEnabled.Should().BeFalse();
+		config.LogTargets.Should().Be(LogTargets.None);
+	}
+
+	[Theory]
+	//only specifying apm_log_level not sufficient, needs explicit directory configuration
+	//setting targets to none will result in no global trace logging
+	[InlineData(ELASTIC_OTEL_LOG_TARGETS, "None")]
+	//setting file log level to none will result in no global trace logging
+	[InlineData(ELASTIC_OTEL_LOG_LEVEL, "None")]
+	public void CheckNonActivation(string environmentVariable, string value)
+	{
+		var config = new ElasticOpenTelemetryOptions(new Hashtable { { environmentVariable, value } });
+		config.GlobalLogEnabled.Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData("trace", LogLevel.Trace)]
+	[InlineData("Trace", LogLevel.Trace)]
+	[InlineData("TraCe", LogLevel.Trace)]
+	[InlineData("debug", LogLevel.Debug)]
+	[InlineData("info", LogLevel.Information)]
+	[InlineData("warn", LogLevel.Warning)]
+	[InlineData("error", LogLevel.Error)]
+	[InlineData("none", LogLevel.None)]
+	public void Check_LogLevelValues_AreMappedCorrectly(string envVarValue, LogLevel logLevel)
+	{
+		Check(ELASTIC_OTEL_LOG_LEVEL, envVarValue, logLevel);
+		return;
+
+		static void Check(string key, string envVarValue, LogLevel level)
+		{
+			var config = CreateConfig(key, envVarValue);
+			config.LogLevel.Should().Be(level, "{0}", key);
+		}
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("foo")]
+	[InlineData("tracing")]
+	public void Check_InvalidLogLevelValues_AreMappedToDefaultWarn(string? envVarValue)
+	{
+		Check(ELASTIC_OTEL_LOG_LEVEL, envVarValue);
+		return;
+
+		static void Check(string key, string? envVarValue)
+		{
+			var config = CreateConfig(key, envVarValue);
+			config.LogLevel.Should().Be(LogLevel.Warning, "{0}", key);
+		}
+	}
+
+	[Fact]
+	public void Check_LogDir_IsEvaluatedCorrectly()
+	{
+		Check(ELASTIC_OTEL_LOG_DIRECTORY, "/foo/bar");
+		return;
+
+		static void Check(string key, string envVarValue)
+		{
+			var config = CreateConfig(key, envVarValue);
+			config.LogDirectory.Should().StartWith("/foo/bar", "{0}", key);
+		}
+	}
+
+	[Theory]
+	[InlineData(null, LogTargets.None)]
+	[InlineData("", LogTargets.None)]
+	[InlineData("foo", LogTargets.None)]
+	[InlineData("foo,bar", LogTargets.None)]
+	[InlineData("foo;bar", LogTargets.None)]
+	[InlineData("file;foo;bar", LogTargets.File)]
+	[InlineData("file", LogTargets.File)]
+	[InlineData("stdout", LogTargets.StdOut)]
+	[InlineData("StdOut", LogTargets.StdOut)]
+	[InlineData("file;stdout", LogTargets.File | LogTargets.StdOut)]
+	[InlineData("FILE;StdOut", LogTargets.File | LogTargets.StdOut)]
+	[InlineData("file;stdout;file", LogTargets.File | LogTargets.StdOut)]
+	[InlineData("FILE;StdOut;stdout", LogTargets.File | LogTargets.StdOut)]
+	internal void Check_LogTargets_AreEvaluatedCorrectly(string? envVarValue, LogTargets? targets)
+	{
+		Check(ELASTIC_OTEL_LOG_TARGETS, envVarValue, targets);
+		return;
+
+		static void Check(string key, string? envVarValue, LogTargets? targets)
+		{
+			var config = CreateConfig(key, envVarValue);
+			config.LogTargets.Should().Be(targets, "{0}", key);
+		}
+	}
+
+	private static ElasticOpenTelemetryOptions CreateConfig(string key, string? envVarValue)
+	{
+		var environment = new Hashtable { { key, envVarValue } };
+		return new ElasticOpenTelemetryOptions(environment);
+	}
+}


### PR DESCRIPTION
This ensure the same environment configuration keys exist in both the old and new agent:

https://github.com/elastic/apm-agent-dotnet/pull/2371

* ELASTIC_OTEL_LOG_LEVEL
* ELASTIC_OTEL_LOG_DIRECTORY
* ELASTIC_OTEL_LOG_TARGETS

Including the same defaulting behaviour (copy pasted the tests from that PR into this).

The default is no global logging unless any of these are set to a value other than:

`ELASTIC_OTEL_LOG_LEVEL=none` or `ELASTIC_OTEL_LOG_TARGETS=none`


`ELASTIC_OTEL_LOG_TARGETS=stdout` currently does not do anything, looking to tackle that in a follow up PR.