### PR TITLE
github-actions: use github secrets

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,8 +25,10 @@ concurrency:
 env:
   # (keep_serverless-staging-oblt, keep_serverless-qa-oblt or serverless-production-oblt)
   SERVERLESS_PROJECT: serverless-production-oblt
-  # (staging, qa or pro)
-  VAULT_SECRET_SUFFIX: pro
+  # Secrets managed through IasC, if you need a different environment please reach the obs robots team
+  ## TODO: Use Keyless
+  E2E__BROWSEREMAIL: ${{ secrets.OBSERVABILITY_EC_USERNAME }}
+  E2E__BROWSERPASSWORD: ${{ secrets.OBSERVABILITY_EC_PASSWORD }}
 
 # NOTE: if you add a new job and it's a mandatory check then
 #       update e2e-docs.yml
@@ -49,17 +51,6 @@ jobs:
           github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
           cluster-name:  ${{ env.SERVERLESS_PROJECT }}
 
-      - name: Get the browser email and password from Vault
-        uses: hashicorp/vault-action@v3.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          method: approle
-          secrets: |
-            secret/observability-team/ci/elastic-cloud/observability-team-${{ env.VAULT_SECRET_SUFFIX }} username | E2E__BROWSEREMAIL ;
-            secret/observability-team/ci/elastic-cloud/observability-team-${{ env.VAULT_SECRET_SUFFIX }} password | E2E__BROWSERPASSWORD
-        
       - name: End-to-end tests
         run: ./build.sh test --test-suite=e2e
         env: 


### PR DESCRIPTION
Vault free.

Tests are failing:

```

   ⚡️ FAIL  Elastic.OpenTelemetry.EndToEndTests.EndToEndTests.LatencyShowsAGraph
  
  Error: System.TimeoutException : Timeout 30000ms exceeded.
  Call log:
    - waiting for GetByRole(AriaRole.Heading, new() { Name = "Services" }) to be visible
  
    Failed Elastic.OpenTelemetry.EndToEndTests.EndToEndTests.LatencyShowsAGraph [2 s]
    Error Message:
     System.TimeoutException : Timeout 30000ms exceeded.
  Call log:
    - waiting for GetByRole(AriaRole.Heading, new() { Name = "Services" }) to be visible
    Stack Trace:
       at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 207
     at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal) in /_/src/Playwright/Transport/Connection.cs:line 537
     at Elastic.OpenTelemetry.EndToEndTests.DistributedFixture.ApmUIBrowserContext.WaitForServiceOnOverview(IPage page) in /home/runner/work/elastic-otel-dotnet/elastic-otel-dotnet/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/ApmUIBrowserContext.cs:line 95
     at Elastic.OpenTelemetry.EndToEndTests.DistributedFixture.ApmUIBrowserContext.InitializeAsync() in /home/runner/work/elastic-otel-dotnet/elastic-otel-dotnet/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/ApmUIBrowserContext.cs:line 50
     at Elastic.OpenTelemetry.EndToEndTests.DistributedFixture.ApmUIBrowserContext.InitializeAsync() in /home/runner/work/elastic-otel-dotnet/elastic-otel-dotnet/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/ApmUIBrowserContext.cs:line 60
     at Elastic.OpenTelemetry.EndToEndTests.DistributedFixture.DistributedApplicationFixture.InitializeAsync() in /home/runner/work/elastic-otel-dotnet/elastic-otel-dotnet/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/DistributedApplicationFixture.cs:line 114
     at Nullean.Xunit.Partitions.Sdk.PartitionTestAssemblyRunner.UseStateAndRun(IPartitionLifetime partition, Func`2 runGroup, Func`3 failAll)
    Standard Output Messages:
   Timeout 30000ms exceeded.
   Call log:
     - waiting for GetByRole(AriaRole.Heading, new() { Name = "Services" }) to be visible
```

Similarly happening in `main`:
- https://github.com/elastic/elastic-otel-dotnet/actions/runs/9578099798


