### PR TITLE
Distribution packaging continued

### DIFF
--- a/.github/workflows/bootstrap/action.yml
+++ b/.github/workflows/bootstrap/action.yml
@@ -26,6 +26,14 @@ runs:
         restore-keys: |
           ${{ runner.os }}-nuget
           
+    # ensures we don't hit GitHub releases all the time to download the OpenTelemetry auto instrumentation assets
+    # if not available they will be download in .artifacts/otel-distribution/{otel-version}
+    - name: Cache OpenTelemetry Distribution
+      uses: actions/cache@v4
+      with:
+        path: .artifacts/otel-distribution
+        key: otel-distribution
+    
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
         
       - name: Test
         run: build.sh test --test-suite=skip-e2e
-        shell: cmd
 
       # We still run the full release build on pull-requests this ensures packages are validated ahead of time
       - name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/workflows/bootstrap
         
       - name: Test
-        run: build.sh test --test-suite=skip-e2e
+        run: ./build.sh test --test-suite=skip-e2e
 
       # We still run the full release build on pull-requests this ensures packages are validated ahead of time
       - name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-        
 
       - name: Bootstrap Action Workspace
         id: bootstrap
@@ -53,3 +52,23 @@ jobs:
       # We still run the full release build on pull-requests this ensures packages are validated ahead of time
       - name: Release
         run: ./build.sh release --test-suite=skip-e2e
+  
+  container-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - machine: ubuntu-20.04
+          - machine: ubuntu-20.04
+            base-image: alpine-x64
+            os-type: linux-musl
+            # architecture: "x64"
+          - machine: [self-hosted, Linux, ARM64]
+            base-image: alpine-arm64
+            os-type: linux-musl
+            # architecture: "arm64"
+          - machine: [self-hosted, Linux, ARM64]
+            base-image: debian-arm64
+            os-type: linux-glibc
+            # architecture: "arm64"
+    runs-on: ${{ matrix.machine }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
 
       # We still run the full release build on pull-requests this ensures packages are validated ahead of time
       - name: Release
-        run: ./build.sh release
+        run: ./build.sh release -c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,27 +48,11 @@ jobs:
       - name: Bootstrap Action Workspace
         id: bootstrap
         uses: ./.github/workflows/bootstrap
+        
+      - name: Test
+        run: build.sh test --test-suite=skip-e2e
+        shell: cmd
 
       # We still run the full release build on pull-requests this ensures packages are validated ahead of time
       - name: Release
-        run: ./build.sh release --test-suite=skip-e2e
-  
-  container-build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - machine: ubuntu-20.04
-          - machine: ubuntu-20.04
-            base-image: alpine-x64
-            os-type: linux-musl
-            # architecture: "x64"
-          - machine: [self-hosted, Linux, ARM64]
-            base-image: alpine-arm64
-            os-type: linux-musl
-            # architecture: "arm64"
-          - machine: [self-hosted, Linux, ARM64]
-            base-image: debian-arm64
-            os-type: linux-glibc
-            # architecture: "arm64"
-    runs-on: ${{ matrix.machine }}
+        run: ./build.sh release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        
 
       - name: Bootstrap Action Workspace
         id: bootstrap

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,7 +26,10 @@ jobs:
         id: bootstrap
         uses: ./.github/workflows/bootstrap
 
-      - run: ./build.sh release
+      - name: Test
+        run: ./build.sh test --test-suite=skip-e2e
+
+      - run: ./build.sh release -c
         name: Release
         
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,6 +10,7 @@ permissions:
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
   RELEASE_PACKAGES: ".artifacts/package/release/*.nupkg"
+  RELEASE_DISTRO: ".artifacts/elastic-distribution/*"
 
 jobs:
   release:
@@ -27,11 +28,22 @@ jobs:
 
       - run: ./build.sh release
         name: Release
+        
+      - uses: actions/upload-artifact@v4
+        with:
+          name: elastic-distribution
+          path: ${{ env.RELEASE_DISTRO }}
 
-      - name: Generate build provenance
+      - name: Generate build provenance (Distribution)
+        uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0  # v1.3.3
+        with:
+          subject-path: "${{ github.workspace }}/${{ env.RELEASE_DISTRO }}"
+          
+      - name: Generate build provenance (Packages)
         uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0  # v1.3.3
         with:
           subject-path: "${{ github.workspace }}/${{ env.RELEASE_PACKAGES }}"
+
 
       # Push to feedz.io 
       - name: publish canary packages to feedz.io

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,7 +25,7 @@ jobs:
         id: bootstrap
         uses: ./.github/workflows/bootstrap
 
-      - run: ./build.sh release --test-suite=skip-e2e
+      - run: ./build.sh release
         name: Release
 
       - name: Generate build provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       id: bootstrap
       uses: ./.github/workflows/bootstrap
 
-    - run: ./build.sh release --test-suite=skip-all
+    - run: ./build.sh release
       name: Release
 
     - name: Generate build provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ env:
   JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   SLACK_CHANNEL: "#apm-agent-dotnet"
   RELEASE_PACKAGES: ".artifacts/package/release/*.nupkg"
+  RELEASE_DISTRO: ".artifacts/elastic-distribution/*"
 
 jobs:
   release:
@@ -34,7 +35,18 @@ jobs:
     - run: ./build.sh release
       name: Release
 
-    - name: Generate build provenance
+    - name: Attach Distribution to release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload ${{ github.ref_name }} "${{ env.RELEASE_DISTRO }}"
+
+    - name: Generate build provenance (Distribution)
+      uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0  # v1.3.3
+      with:
+        subject-path: "${{ github.workspace }}/${{ env.RELASE_DISTRO }}"
+        
+    - name: Generate build provenance (Packages)
       uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0  # v1.3.3
       with:
         subject-path: "${{ github.workspace }}/${{ env.RELEASE_PACKAGES }}"

--- a/build/patch-dotnet-auto-install.sh
+++ b/build/patch-dotnet-auto-install.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -e
+
+# guess OS_TYPE if not provided
+if [ -z "$OS_TYPE" ]; then
+  case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+    cygwin_nt*|mingw*|msys_nt*)
+      OS_TYPE="windows"
+      ;;
+    linux*)
+      if [ "$(ldd /bin/ls | grep -m1 'musl')" ]; then
+        OS_TYPE="linux-musl"
+      else
+        OS_TYPE="linux-glibc"
+      fi
+      ;;
+    darwin*)
+      OS_TYPE="macos"
+      ;;
+  esac
+fi
+
+case "$OS_TYPE" in
+  "linux-glibc"|"linux-musl"|"macos"|"windows")
+    ;;
+  *)
+    echo "Set the operating system type using the OS_TYPE environment variable. Supported values: linux-glibc, linux-musl, macos, windows." >&2
+    exit 1
+    ;;
+esac
+
+# guess OS architecture if not provided
+if [ -z "$ARCHITECTURE" ]; then
+  case $(uname -m) in
+    x86_64)  ARCHITECTURE="x64" ;;
+    aarch64) ARCHITECTURE="arm64" ;;
+  esac
+fi
+
+case "$ARCHITECTURE" in
+  "x64"|"arm64")
+    ;;
+  *)
+    echo "Set the architecture type using the ARCHITECTURE environment variable. Supported values: x64, arm64." >&2
+    exit 1
+    ;;
+esac
+
+test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
+test -z "$VERSION" && VERSION="v1.7.0"
+
+DOWNLOAD_DIR="${DOWNLOAD_DIR:=${TMPDIR:=$(mktemp -d)}}"
+
+RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
+ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"
+
+# In case of Linux, use architecture in the download path
+if echo "$OS_TYPE" | grep -q "linux"; then
+  ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE-$ARCHITECTURE.zip"
+fi
+
+LOCAL_PATH="${LOCAL_PATH:=$DOWNLOAD_DIR/$ARCHIVE}"
+if [ ! -f "${LOCAL_PATH}" ]; then
+  (
+    cd "$DOWNLOAD_DIR"
+    echo "Downloading $VERSION for $OS_TYPE ($LOCAL_PATH)..."
+    curl -sSfLo "$LOCAL_PATH" "$RELEASES_URL/download/$VERSION/$ARCHIVE"
+  )
+else
+  echo "Using local installation archive: $LOCAL_PATH"
+fi
+
+rm -rf "$OTEL_DOTNET_AUTO_HOME"
+unzip -q "$TMPFILE" -d "$OTEL_DOTNET_AUTO_HOME"

--- a/build/patch-dotnet-auto-install.sh
+++ b/build/patch-dotnet-auto-install.sh
@@ -71,4 +71,4 @@ else
 fi
 
 rm -rf "$OTEL_DOTNET_AUTO_HOME"
-unzip -q "$TMPFILE" -d "$OTEL_DOTNET_AUTO_HOME"
+unzip -q "$LOCAL_PATH" -d "$OTEL_DOTNET_AUTO_HOME"

--- a/build/scripts/BuildInformation.fs
+++ b/build/scripts/BuildInformation.fs
@@ -14,7 +14,7 @@ open Proc.Fs
 open Fake.Tools.Git
 
 type Paths =
-    static member private Root =
+    static member Root =
         let mutable dir = DirectoryInfo(".")
         while dir.GetFiles("*.sln").Length = 0 do dir <- dir.Parent
         Environment.CurrentDirectory <- dir.FullName

--- a/build/scripts/CommandLine.fs
+++ b/build/scripts/CommandLine.fs
@@ -18,6 +18,7 @@ type TestSuite = All | Unit | Integration | E2E | Skip_All | Skip_E2E
 type Build =
     | [<CliPrefix(CliPrefix.None);SubCommand>] Clean
     | [<CliPrefix(CliPrefix.None);SubCommand>] Version
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] Compile
     | [<CliPrefix(CliPrefix.None);SubCommand>] Build
     | [<CliPrefix(CliPrefix.None);SubCommand>] Test
     
@@ -64,6 +65,7 @@ with
             | ValidateLicenses
             | ValidatePackages
             | GenerateReleaseNotes
+            | Compile 
             | Redistribute
             | GenerateApiChanges -> "Undocumented, dependent target"
             

--- a/build/scripts/Packaging.fs
+++ b/build/scripts/Packaging.fs
@@ -68,7 +68,7 @@ let downloadArtifacts (_:ParseResults<Build>) =
 let injectPluginFiles (asset: ReleaseAsset) (stagedZip: FileInfo) tfm target  = 
     use zipArchive = ZipFile.Open(stagedZip.FullName, ZipArchiveMode.Update)
     pluginFiles tfm  |> List.iter(fun f ->
-        printfn $"Staging zip: %s{asset.Name}, Adding: %s{f.Name} (%s{tfm}_ to %s{target}"
+        printfn $"Staging zip: %s{stagedZip.Name}, Adding: %s{f.Name} (%s{tfm}) to %s{target}"
         zipArchive.CreateEntryFromFile(f.FullName, Path.Combine(target, f.Name)) |> ignore
     )
     
@@ -93,7 +93,7 @@ let stageArtifacts (assets:List<ReleaseAsset * FileInfo>) =
         path.MoveTo(distro.FullName, true)
         distro.Refresh()
         
-        printfn $"Created: %s{distro.FullName}"
+        printfn $"Moved staging to: %s{distro.FullName}"
     )
     stagedZips
     
@@ -101,11 +101,13 @@ let stageArtifacts (assets:List<ReleaseAsset * FileInfo>) =
   
 let redistribute (arguments:ParseResults<Build>) =
     let assets = downloadArtifacts arguments
-    let staged = stageArtifacts assets
-        
     printfn ""
     assets |> List.iter (fun (asset, path) ->
         printfn "Asset: %s" asset.Name
     )
+    
+    let staged = stageArtifacts assets
+    ignore()
+        
     
     

--- a/build/scripts/Packaging.fs
+++ b/build/scripts/Packaging.fs
@@ -14,7 +14,7 @@ open BuildInformation
 open CommandLine
 open Octokit
 
-let private otelAutoVersion = BuildConfiguration.OpenTelemetryAutoInstrumentationVersion;
+let private otelAutoVersion = Software.OpenTelemetryAutoInstrumentationVersion;
 
 let private downloadFolder = Path.Combine(".artifacts", "otel-distribution", otelAutoVersion.AsString) |> Directory.CreateDirectory
 let private distroFolder = Path.Combine(".artifacts", "elastic-distribution", otelAutoVersion.AsString) |> Directory.CreateDirectory

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -168,8 +168,8 @@ let Setup (parsed:ParseResults<Build>) =
         | Version -> Build.Step version
         | Clean -> Build.Cmd [Version] [] clean
         | Compile -> Build.Step compile
-        | Redistribute -> Build.Step Packaging.redistribute
-        | Build -> Build.Cmd [Clean; CheckFormat; Compile; Redistribute] [] build
+        | Redistribute -> Build.Cmd [Compile;] [] Packaging.redistribute
+        | Build -> Build.Cmd [Clean; CheckFormat; Redistribute] [] build
         
         | End_To_End -> Build.Cmd [] [Build] <| runTests E2E
         | Integrate -> Build.Cmd [] [Build] <| runTests Integration

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -29,6 +29,10 @@ let private version _ =
     let version = Software.Version
     printfn $"Informational version: %s{version.AsString}"
     printfn $"Semantic version: %s{version.NormalizeToShorter()}"
+    let otelVersion = Software.OpenTelemetryVersion;
+    printfn $"OpenTelemetry version: %s{otelVersion.AsString}"
+    let otelAutoVersion = Software.OpenTelemetryAutoInstrumentationVersion;
+    printfn $"OpenTelemetry Auto Instrumentation version: %s{otelAutoVersion.AsString}"
     
 let private generatePackages _ = exec { run "dotnet" "pack" }
 

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -168,17 +168,18 @@ let Setup (parsed:ParseResults<Build>) =
         | Version -> Build.Step version
         | Clean -> Build.Cmd [Version] [] clean
         | Compile -> Build.Step compile
-        | Redistribute -> Build.Cmd [Compile;] [] Packaging.redistribute
-        | Build -> Build.Cmd [Clean; CheckFormat; Redistribute] [] build
+        | Build -> Build.Cmd [Clean; CheckFormat; Compile] [] build
         
         | End_To_End -> Build.Cmd [] [Build] <| runTests E2E
         | Integrate -> Build.Cmd [] [Build] <| runTests Integration
         | Unit_Test -> Build.Cmd [] [Build] <| runTests Unit
         | Test -> Build.Cmd [] [Build] test
         
+        | Redistribute -> Build.Cmd [Compile;] [] Packaging.redistribute
+        
         | Release -> 
             Build.Cmd 
-                [PristineCheck; Build]
+                [PristineCheck; Build; Redistribute]
                 [ValidateLicenses; GeneratePackages; ValidatePackages; GenerateReleaseNotes; GenerateApiChanges]
                 release
 

--- a/examples/Example.AutoInstrumentation/README.md
+++ b/examples/Example.AutoInstrumentation/README.md
@@ -18,3 +18,9 @@ To quickly see the `DockerFile`  in action run the following from the root of th
 $ docker build -t example.autoinstrumentation:latest -f examples/Example.AutoInstrumentation/Dockerfile --no-cache . && \
    docker run -it --rm -p 5000:8080 --name autoin example.autoinstrumentation:latest
 ```
+
+
+```bash
+docker build -t distribution.autoinstrumentation:latest -f examples/Example.AutoInstrumentation/distribution.Dockerfile --platform linux/arm64 --no-cache . && \
+         docker run -it --rm -p 5000:8080 --name distri --platform linux/arm64 distribution.autoinstrumentation:latest
+```

--- a/examples/Example.AutoInstrumentation/distribution.Dockerfile
+++ b/examples/Example.AutoInstrumentation/distribution.Dockerfile
@@ -27,7 +27,7 @@ COPY ".artifacts/otel-distribution" /distro/otel
 
 COPY --from=build /app/example /app/example
 
-RUN OTEL_DOTNET_AUTO_HOME="/app/otel" TMPDIR="/distro/elastic/1.7.0" sh /distro/otel/1.7.0/otel-dotnet-auto-install.sh
+RUN OTEL_DOTNET_AUTO_HOME="/app/otel" DOWNLOAD_DIR="/distro/elastic/1.7.0" sh /distro/otel/1.7.0/otel-dotnet-auto-install.sh
 
 ENV OTEL_DOTNET_AUTO_HOME="/app/otel"
 ENV OTEL_LOG_LEVEL=debug

--- a/examples/Example.AutoInstrumentation/distribution.Dockerfile
+++ b/examples/Example.AutoInstrumentation/distribution.Dockerfile
@@ -23,13 +23,12 @@ RUN dotnet publish "${_PROJECT}.csproj" -c Release -a $TARGETARCH --no-restore  
 FROM build AS final
 
 COPY ".artifacts/elastic-distribution" /distro/elastic
-COPY ".artifacts/otel-distribution" /distro/otel
 
 COPY --from=build /app/example /app/example
 
 ENV OTEL_DOTNET_AUTO_HOME="/app/otel"
 # Use already downloaded release assets (call ./build.sh redistribute locally if you run this dockerfile manually)
-RUN DOWNLOAD_DIR="/distro/elastic/1.7.0" sh /distro/otel/1.7.0/otel-dotnet-auto-install.sh
+RUN DOWNLOAD_DIR="/distro/elastic" sh /distro/elastic/elastic-dotnet-auto-install.sh
 
 ENV OTEL_LOG_LEVEL=debug
 ENTRYPOINT ["sh", "/app/otel/instrument.sh", "dotnet", "/app/example/Example.AutoInstrumentation.dll"]

--- a/examples/Example.AutoInstrumentation/distribution.Dockerfile
+++ b/examples/Example.AutoInstrumentation/distribution.Dockerfile
@@ -27,9 +27,9 @@ COPY ".artifacts/otel-distribution" /distro/otel
 
 COPY --from=build /app/example /app/example
 
-RUN OTEL_DOTNET_AUTO_HOME="/app/otel" DOWNLOAD_DIR="/distro/elastic/1.7.0" sh /distro/otel/1.7.0/otel-dotnet-auto-install.sh
-
 ENV OTEL_DOTNET_AUTO_HOME="/app/otel"
+# Use already downloaded release assets (call ./build.sh redistribute locally if you run this dockerfile manually)
+RUN DOWNLOAD_DIR="/distro/elastic/1.7.0" sh /distro/otel/1.7.0/otel-dotnet-auto-install.sh
+
 ENV OTEL_LOG_LEVEL=debug
-ENV OTEL_DOTNET_AUTO_PLUGINS="Elastic.OpenTelemetry.AutoInstrumentationPlugin, Elastic.OpenTelemetry, Version=1.0.0.0, Culture=neutral, PublicKeyToken=069ca2728db333c1"
 ENTRYPOINT ["sh", "/app/otel/instrument.sh", "dotnet", "/app/example/Example.AutoInstrumentation.dll"]

--- a/examples/Example.AutoInstrumentation/distribution.Dockerfile
+++ b/examples/Example.AutoInstrumentation/distribution.Dockerfile
@@ -1,0 +1,35 @@
+ARG OTEL_VERSION=1.7.0
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ENV _PROJECT="Example.AutoInstrumentation"
+ENV _PROJECTPATH="${_PROJECT}/${_PROJECT}.csproj"
+
+RUN apt-get update && apt-get install -y unzip
+
+WORKDIR /work
+
+COPY ["examples/${_PROJECTPATH}", "examples/${_PROJECT}/"]
+RUN dotnet restore -a $TARGETARCH "examples/${_PROJECT}"
+
+COPY .git .git
+COPY examples/${_PROJECT} examples/${_PROJECT}
+WORKDIR "/work/examples/${_PROJECT}"
+RUN dotnet publish "${_PROJECT}.csproj" -c Release -a $TARGETARCH --no-restore  -o /app/example
+
+
+FROM build AS final
+
+COPY ".artifacts/elastic-distribution" /distro/elastic
+COPY ".artifacts/otel-distribution" /distro/otel
+
+COPY --from=build /app/example /app/example
+
+RUN OTEL_DOTNET_AUTO_HOME="/app/otel" TMPDIR="/distro/elastic/1.7.0" sh /distro/otel/1.7.0/otel-dotnet-auto-install.sh
+
+ENV OTEL_DOTNET_AUTO_HOME="/app/otel"
+ENV OTEL_LOG_LEVEL=debug
+ENV OTEL_DOTNET_AUTO_PLUGINS="Elastic.OpenTelemetry.AutoInstrumentationPlugin, Elastic.OpenTelemetry, Version=1.0.0.0, Culture=neutral, PublicKeyToken=069ca2728db333c1"
+ENTRYPOINT ["sh", "/app/otel/instrument.sh", "dotnet", "/app/example/Example.AutoInstrumentation.dll"]


### PR DESCRIPTION
Continues #133 

This now puts all required distributions under `.artifacts/elastic-distribution`. 

This includes `elastic-*.zip` versions of the auto instrumentation zips. 
These zips include
	* our plugin dll (twice for -windows.zip).
	* `_instrument.sh` a copy of the original `instrument.sh`
	* `instrument.sh` which sets our plugin var and calls `_instrument.sh`

This also includes elastic versions of the installation bash script and the powershell module to instrument and install/update on windows.

These files should now upload as part of our release and uploaded as artifacts on each commit in main.

Locally to build the distributables call:

```
./build.sh redistribute
````

To validate the distribution there is now a new dockerfile that validates our install and instrumentation scripts:

```bash
docker build -t distribution.autoinstrumentation:latest -f examples/Example.AutoInstrumentation/distribution.Dockerfile  . && \
         docker run -it --rm -p 5000:8080 --name distri --platform linux/arm64 distribution.autoinstrumentation:latest
```


The latter will also form the basis for more integration tests which i'll follow up with