### PR TITLE
Dont upload artifacts on each commit to main

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -32,11 +32,6 @@ jobs:
       - run: ./build.sh release -c
         name: Release
         
-      - uses: actions/upload-artifact@v4
-        with:
-          name: elastic-distribution
-          path: ${{ env.RELEASE_DISTRO }}
-
       - name: Generate build provenance (Distribution)
         uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0  # v1.3.3
         with:
@@ -46,7 +41,6 @@ jobs:
         uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0  # v1.3.3
         with:
           subject-path: "${{ github.workspace }}/${{ env.RELEASE_PACKAGES }}"
-
 
       # Push to feedz.io 
       - name: publish canary packages to feedz.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,21 +35,22 @@ jobs:
     - run: ./build.sh release
       name: Release
 
-    - name: Attach Distribution to release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh release upload ${{ github.ref_name }} "${{ env.RELEASE_DISTRO }}"
-
     - name: Generate build provenance (Distribution)
       uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0  # v1.3.3
       with:
-        subject-path: "${{ github.workspace }}/${{ env.RELASE_DISTRO }}"
+        subject-path: "${{ github.workspace }}/${{ env.RELEASE_DISTRO }}"
         
     - name: Generate build provenance (Packages)
       uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0  # v1.3.3
       with:
         subject-path: "${{ github.workspace }}/${{ env.RELEASE_PACKAGES }}"
+        
+    - name: Attach Distribution to release
+      if: ${{ github.event_name == 'release' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload ${{ github.ref_name }} '${{ env.RELEASE_DISTRO }}'
 
     - name: Release to Nuget (only for release events)
       if: ${{ github.event_name == 'release' }}

--- a/build/scripts/Packaging.fs
+++ b/build/scripts/Packaging.fs
@@ -129,7 +129,7 @@ let stageInstrumentationScript (stagedZips:List<ReleaseAsset * FileInfo>) =
     let wrapperScript = downloadFileInfo "instrument.sh"
     let copyScript = Path.Combine("src", "Elastic.OpenTelemetry.AutoInstrumentation", "instrument.sh") |> FileInfo
     let script = copyScript.CopyTo(wrapperScript.FullName, true)
-    (stageVersion, script)
+    (stageScript, script)
 
 let stageInstallationBashScript () =
     let installScript = downloadFileInfo "otel-dotnet-auto-install.sh"


### PR DESCRIPTION
See: https://github.com/elastic/elastic-otel-dotnet/actions/runs/10185795296

Since the zips are 50megs total this will get excessive quick

This also guards that we only upload to a release when we are publishing a release.

Hopefully this will fix the glob issue here too: https://github.com/elastic/elastic-otel-dotnet/actions/runs/10185795294/job/28176108962