### PR TITLE
Replacing versions in urls should not include 'v' prefix.

### DIFF
--- a/build/scripts/Packaging.fs
+++ b/build/scripts/Packaging.fs
@@ -143,7 +143,7 @@ let stageInstallationBashScript () =
         (File.ReadAllText patchScript.FullName)
             .Replace("/open-telemetry/opentelemetry-dotnet-instrumentation/", "/elastic/elastic-otel-dotnet/")
             .Replace("opentelemetry-dotnet-instrumentation", "elastic-dotnet-instrumentation")
-            .Replace("v" + Software.OpenTelemetryAutoInstrumentationVersion.AsString, "v" + Software.Version.NormalizeToShorter())
+            .Replace("v" + Software.OpenTelemetryAutoInstrumentationVersion.AsString, Software.Version.NormalizeToShorter())
             
     let elasticInstall = distroFile installScript
     File.WriteAllText(elasticInstall.FullName, contents)
@@ -167,7 +167,7 @@ let stageInstallationPsScript () =
                      ]
                      |> String.concat "\r\n        "
             )
-            .Replace("v" + Software.OpenTelemetryAutoInstrumentationVersion.AsString, "v" + Software.Version.NormalizeToShorter())
+            .Replace("v" + Software.OpenTelemetryAutoInstrumentationVersion.AsString, Software.Version.NormalizeToShorter())
     let elasticInstall = distroFile installScript
     //ensure we write our new module name
     File.WriteAllText(elasticInstall.FullName.Replace("elastic.DotNet.Auto", "Elastic.OpenTelemetry.DotNet"), contents);


### PR DESCRIPTION
Our releases are not prefixed with `v` like the upstream distribution. 

So we need ensure we don't attempt to download our assets from releases prefixed with 'v'`.