### PR TITLE
Update to .NET 9 SDK + 1.10 OTel SDK

### DIFF
--- a/.github/.github.csproj
+++ b/.github/.github.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
 

--- a/.github/workflows/bootstrap/action.yml
+++ b/.github/workflows/bootstrap/action.yml
@@ -39,10 +39,6 @@ runs:
       with:
         global-json-file: ./global.json
 
-    - name: Install Aspire workload
-      shell: bash
-      run: dotnet workload install aspire
-
     - id: dotnet
       shell: bash
       run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/build/build.fsproj
+++ b/build/build.fsproj
@@ -1,35 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.4"/>
-    <PackageReference Include="Bullseye" Version="4.2.1"/>
+    <PackageReference Include="Argu" Version="6.1.4" />
+    <PackageReference Include="Bullseye" Version="4.2.1" />
     <PackageReference Include="Octokit" Version="13.0.1" />
-    <PackageReference Include="Proc.Fs" Version="0.8.1"/>
-    <PackageReference Include="Fake.Tools.Git" Version="5.20.3"/>
-    <PackageReference Remove="FSharp.Core"/>
-    <PackageReference Include="FSharp.Core" Version="8.0.101"/>
+    <PackageReference Include="Proc.Fs" Version="0.8.1" />
+    <PackageReference Include="Fake.Tools.Git" Version="5.20.3" />
+    <PackageReference Remove="FSharp.Core" />
+    <PackageReference Include="FSharp.Core" Version="8.0.101" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\*" LinkBase="_root"/>
+    <None Include="..\*" LinkBase="_root" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="scripts\BuildInformation.fs"/>
-    <Compile Include="scripts\CommandLine.fs"/>
+    <Compile Include="scripts\BuildInformation.fs" />
+    <Compile Include="scripts\CommandLine.fs" />
     <Compile Include="scripts\Packaging.fs" />
-    <Compile Include="scripts\Targets.fs"/>
-    <Compile Include="scripts\Program.fs"/>
-    <None Include="**\*"/>
-    <None Remove="bin\**"/>
-    <None Remove="obj\**"/>
-    <None Remove="scripts\**"/>
-    <None Remove="output\**"/>
+    <Compile Include="scripts\Targets.fs" />
+    <Compile Include="scripts\Program.fs" />
+    <None Include="**\*" />
+    <None Remove="bin\**" />
+    <None Remove="obj\**" />
+    <None Remove="scripts\**" />
+    <None Remove="output\**" />
   </ItemGroup>
 
 </Project>

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -76,7 +76,7 @@ let private runTests suite _ =
         
     
     let settingsArg = ["-s"; "tests/.runsettings"]
-    let tfmArgs = if OS.Current = OS.Windows then [] else ["-f"; "net8.0"]
+    let tfmArgs = if OS.Current = OS.Windows then [] else ["-f"; "net9.0"]
     exec {
         env (Map ["TEST_SUITE", suite.SuitName])
         run "dotnet" (
@@ -128,13 +128,13 @@ let private generateApiChanges _ =
     nugetPackages
     |> Seq.iter(fun p ->
         let outputFile = Path.Combine(output, $"breaking-changes-%s{p}.md")
-        let tfm = "net8.0"
+        let tfm = "net9.0"
         let args =
             [
                 "assembly-differ"
                 $"previous-nuget|%s{p}|%s{currentVersion}|%s{tfm}";
                 //$"directory|.artifacts/bin/%s{p}/release/%s{tfm}";
-                $"directory|.artifacts/bin/%s{p}/release_net8.0";
+                $"directory|.artifacts/bin/%s{p}/release_net9.0";
                 "-a"; "true"; "--target"; p; "-f"; "github-comment"; "--output"; outputFile
             ]
         exec { run "dotnet" args }

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "minver-cli": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "commands": [
         "minver"
       ]

--- a/examples/AppHost/AppHost.csproj
+++ b/examples/AppHost/AppHost.csproj
@@ -1,15 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/AppHost/Properties/launchSettings.json
+++ b/examples/AppHost/Properties/launchSettings.json
@@ -1,15 +1,16 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "http": {
+    "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:15114",
+      "applicationUrl": "https://localhost:15114",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16161"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16161",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22052"
       }
     }
   }

--- a/examples/Example.AspNetCore.Mvc/Dockerfile
+++ b/examples/Example.AspNetCore.Mvc/Dockerfile
@@ -1,10 +1,10 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["examples/Example.AspNetCore.Mvc/Example.AspNetCore.Mvc.csproj", "examples/Example.AspNetCore.Mvc/"]

--- a/examples/Example.AspNetCore.Mvc/Example.AspNetCore.Mvc.csproj
+++ b/examples/Example.AspNetCore.Mvc/Example.AspNetCore.Mvc.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/examples/Example.AutoInstrumentation/Dockerfile
+++ b/examples/Example.AutoInstrumentation/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG OTEL_VERSION=1.7.0
+ARG OTEL_VERSION=1.9.0
 FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
 ARG TARGETPLATFORM
 ARG TARGETARCH
@@ -18,7 +18,6 @@ ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/relea
 RUN chmod +x otel-dotnet-auto-install.sh
 RUN OTEL_DOTNET_AUTO_HOME="/app/otel" sh otel-dotnet-auto-install.sh
 
-
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build_example
 ENV _PROJECT="Example.AutoInstrumentation"
 ENV _PROJECTPATH="${_PROJECT}/${_PROJECT}.csproj"
@@ -33,7 +32,7 @@ RUN dotnet build "${_PROJECT}.csproj" -c Release -o /app/build_example
 FROM build_example AS publish_example
 RUN dotnet publish "Example.AutoInstrumentation.csproj" -c Release -o /app/example /p:UseAppHost=false
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build_distro
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build_distro
 ENV _PROJECT="Elastic.OpenTelemetry"
 ENV _PROJECTPATH="${_PROJECT}/${_PROJECT}.csproj"
 WORKDIR /work
@@ -49,14 +48,14 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 WORKDIR /app
 COPY --from=publish_example /app/example /app/example
-COPY --from=build_distro /work/.artifacts/bin/Elastic.OpenTelemetry/release_netstandard2.1/Elastic.OpenTelemetry.dll /app/otel/net/
-COPY --from=build_distro /work/.artifacts/bin/Elastic.OpenTelemetry/release_netstandard2.1/Elastic.OpenTelemetry.pdb /app/otel/net/
+COPY --from=build_distro /work/.artifacts/bin/Elastic.OpenTelemetry/release_net8.0/Elastic.OpenTelemetry.dll /app/otel/net/
+COPY --from=build_distro /work/.artifacts/bin/Elastic.OpenTelemetry/release_net8.0/Elastic.OpenTelemetry.pdb /app/otel/net/
 
 ENV CORECLR_ENABLE_PROFILING="1"
 ENV CORECLR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
 ENV CORECLR_PROFILER_PATH="/app/otel/linux-${TARGETARCH}/OpenTelemetry.AutoInstrumentation.Native.so"
 ENV OTEL_DOTNET_AUTO_PLUGINS="Elastic.OpenTelemetry.AutoInstrumentationPlugin, Elastic.OpenTelemetry, Version=1.0.0.0, Culture=neutral, PublicKeyToken=069ca2728db333c1"
-       
+
 ENV OTEL_TRACES_EXPORTER=none
 ENV OTEL_METRICS_EXPORTER=none
 ENV OTEL_LOGS_EXPORTER=none
@@ -64,9 +63,9 @@ ENV OTEL_SERVICE_NAME=ExampleInstrumentation
 
 ENV OTEL_LOG_LEVEL=debug
 ENV OTEL_DOTNET_AUTO_LOG_DIRECTORY=/app/logs
-ENV ELASTIC_OTEL_LOG_TARGETS=stdout
 
 ENV OTEL_DOTNET_AUTO_HOME="/app/otel"
+ENV OTEL_DOTNET_AUTO_LOGGER="console"
 ENV DOTNET_ADDITIONAL_DEPS="/app/otel/AdditionalDeps"
 ENV DOTNET_SHARED_STORE="/app/otel/store"
 ENV DOTNET_STARTUP_HOOKS="/app/otel/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll"

--- a/examples/Example.AutoInstrumentation/Example.AutoInstrumentation.csproj
+++ b/examples/Example.AutoInstrumentation/Example.AutoInstrumentation.csproj
@@ -1,17 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- Can't update to 9.0 yet as the autoinstrumentation store doesn't yet include a net9.0 directory -->
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <Content Include="..\..\.dockerignore">
-        <Link>.dockerignore</Link>
-      </Content>
-    </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\.dockerignore">
+      <Link>.dockerignore</Link>
+    </Content>
+  </ItemGroup>
 
 </Project>

--- a/examples/Example.AutoInstrumentation/distribution.Dockerfile
+++ b/examples/Example.AutoInstrumentation/distribution.Dockerfile
@@ -1,4 +1,4 @@
-ARG OTEL_VERSION=1.7.0
+ARG OTEL_VERSION=1.9.0
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG TARGETPLATFORM
 ARG TARGETARCH
@@ -18,7 +18,6 @@ COPY .git .git
 COPY examples/${_PROJECT} examples/${_PROJECT}
 WORKDIR "/work/examples/${_PROJECT}"
 RUN dotnet publish "${_PROJECT}.csproj" -c Release -a $TARGETARCH --no-restore  -o /app/example
-
 
 FROM build AS final
 

--- a/examples/Example.Console/Example.Console.csproj
+++ b/examples/Example.Console/Example.Console.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
-      <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.15" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.9.0-beta.1" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/Example.MinimalApi/Example.MinimalApi.csproj
+++ b/examples/Example.MinimalApi/Example.MinimalApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/examples/Example.WorkerService/Example.WorkerService.csproj
+++ b/examples/Example.WorkerService/Example.WorkerService.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Example.Elastic.OpenTelemetry.Worker-3a9724de-5d6b-4e68-a21e-b90c655cc721</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/ServiceDefaults/Extensions.cs
+++ b/examples/ServiceDefaults/Extensions.cs
@@ -12,7 +12,9 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace Microsoft.Extensions.Hosting;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 
 public static class Extensions
 {
@@ -30,7 +32,7 @@ public static class Extensions
 			http.AddStandardResilienceHandler();
 
 			// Turn on service discovery by default
-			http.UseServiceDiscovery();
+			http.AddServiceDiscovery();
 		});
 
 		return builder;

--- a/examples/ServiceDefaults/ServiceDefaults.csproj
+++ b/examples/ServiceDefaults/ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
@@ -10,10 +10,10 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.2.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.4.24156.9" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/src/Elastic.OpenTelemetry.AutoInstrumentation/Elastic.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/Elastic.OpenTelemetry.AutoInstrumentation/Elastic.OpenTelemetry.AutoInstrumentation.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net462</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-      <IsPackable>True</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>True</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.7.0"  GeneratePathProperty="true" PrivateAssets="contentfiles" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.9.0" GeneratePathProperty="true" PrivateAssets="contentfiles" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Remove="README.md" />
@@ -18,33 +18,26 @@
           and link it as _instrument.cmd since we manually copy it over in the prebuild event -->
     <Content Update="instrument.cmd" CopyToPublishDirectory="Never" CopyToOutputDirectory="Never" />
     <Content Remove="instrument.cmd" />
-    <Content Include="_instrument.cmd"  CopyToOutputDirectory="Always" CopyToPublishDirectory="Always"
-             Pack="True" PackagePath="contentFiles/any/any/_instrument.cmd"/>
-    <Content Include="instrument.cmd"  CopyToOutputDirectory="Always" CopyToPublishDirectory="Always"
-             Pack="True" PackagePath="contentFiles/any/any/instrument.cmd"/>
+    <Content Include="_instrument.cmd" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Pack="True" PackagePath="contentFiles/any/any/_instrument.cmd" />
+    <Content Include="instrument.cmd" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Pack="True" PackagePath="contentFiles/any/any/instrument.cmd" />
 
     <!-- ensure we remove the linked instrument.sh from base OpenTelemetry.AutoInstrumentation
           and link it as _instrument.sh since we manually copy it over in the prebuild event -->
-    
+
     <Content Update="instrument.sh" CopyToPublishDirectory="Never" CopyToOutputDirectory="Never" />
     <Content Remove="instrument.sh" />
-    <Content Include="_instrument.sh"  CopyToOutputDirectory="Always" CopyToPublishDirectory="Always"
-             Pack="True" PackagePath="contentFiles/any/any/_instrument.sh"/>
-    <Content Include="instrument.sh"  CopyToOutputDirectory="Always" CopyToPublishDirectory="Always"
-             Pack="True" PackagePath="contentFiles/any/any/instrument.sh"/>
-
-    <Content Include="instrument.props"  CopyToOutputDirectory="Always" CopyToPublishDirectory="Always"
-             Pack="True" PackagePath="build/elastic.opentelemetry.autoinstrumentation.props"/>
-
+    <Content Include="_instrument.sh" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Pack="True" PackagePath="contentFiles/any/any/_instrument.sh" />
+    <Content Include="instrument.sh" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Pack="True" PackagePath="contentFiles/any/any/instrument.sh" />
+    <Content Include="instrument.props" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Pack="True" PackagePath="build/elastic.opentelemetry.autoinstrumentation.props" />
   </ItemGroup>
-  
+
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <!-- Copies the content files manually as physical files in the source repository -->
-    <!-- we manually repackage these as contentfiles (albeit renamed) --> 
-    <Copy SourceFiles="$(PkgOpenTelemetry_AutoInstrumentation)/contentFiles/any/any/instrument.cmd" DestinationFiles="$(MSBuildThisFileDirectory)/_instrument.cmd"/>
-    <Copy SourceFiles="$(PkgOpenTelemetry_AutoInstrumentation)/contentFiles/any/any/instrument.sh" DestinationFiles="$(MSBuildThisFileDirectory)/_instrument.sh"/>
+    <!-- we manually repackage these as contentfiles (albeit renamed) -->
+    <Copy SourceFiles="$(PkgOpenTelemetry_AutoInstrumentation)/contentFiles/any/any/instrument.cmd" DestinationFiles="$(MSBuildThisFileDirectory)/_instrument.cmd" />
+    <Copy SourceFiles="$(PkgOpenTelemetry_AutoInstrumentation)/contentFiles/any/any/instrument.sh" DestinationFiles="$(MSBuildThisFileDirectory)/_instrument.sh" />
   </Target>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj" />
   </ItemGroup>

--- a/src/Elastic.OpenTelemetry.AutoInstrumentation/_instrument.cmd
+++ b/src/Elastic.OpenTelemetry.AutoInstrumentation/_instrument.cmd
@@ -1,13 +1,44 @@
 @echo off
-setlocal
+setlocal ENABLEDELAYEDEXPANSION
 
 :: This script is expected to be used in a build that specified a RuntimeIdentifier (RID)
 set BASE_PATH=%~dp0
+set COR_PROFILER_PATH=%BASE_PATH%OpenTelemetry.AutoInstrumentation.Native.dll
+
+:: Validate
+IF EXIST %COR_PROFILER_PATH% (
+    set CORECLR_PROFILER_PATH=!COR_PROFILER_PATH!
+) ELSE (
+    set "COR_PROFILER_PATH="
+
+    echo Unable to locate the native profiler inside current directory, possibly due to runtime identifier not being specified when building/publishing. ^
+Attempting to use the native profiler from runtimes\win-x64\native and runtimes\win-x86\native subdirectories.
+
+    set COR_PROFILER_PATH_64=%BASE_PATH%runtimes\win-x64\native\OpenTelemetry.AutoInstrumentation.Native.dll
+    set COR_PROFILER_PATH_32=%BASE_PATH%runtimes\win-x86\native\OpenTelemetry.AutoInstrumentation.Native.dll
+
+    IF EXIST !COR_PROFILER_PATH_64! (
+        IF EXIST !COR_PROFILER_PATH_32! (
+            set CORECLR_PROFILER_PATH_32=!COR_PROFILER_PATH_32!
+        ) ELSE (
+            set "COR_PROFILER_PATH_32="
+        )
+        set CORECLR_PROFILER_PATH_64=!COR_PROFILER_PATH_64!
+    ) ELSE (
+        set "COR_PROFILER_PATH_64="
+        IF EXIST !COR_PROFILER_PATH_32! (
+            set CORECLR_PROFILER_PATH_32=!COR_PROFILER_PATH_32!
+        ) ELSE (
+            set "COR_PROFILER_PATH_32="
+            echo Unable to locate the native profiler. 1>&2
+            exit /b 1
+        )
+    )
+)
 
 :: Settings for .NET Framework
 set COR_ENABLE_PROFILING=1
 set COR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
-set COR_PROFILER_PATH=%BASE_PATH%OpenTelemetry.AutoInstrumentation.Native.dll
 
 :: On .NET Framework automatic assembly redirection MUST be disabled. This setting
 :: is ignored on .NET. This is necessary because the NuGet package doesn't bring
@@ -20,7 +51,6 @@ set OTEL_DOTNET_AUTO_NETFX_REDIRECT_ENABLED=false
 set ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper
 set CORECLR_ENABLE_PROFILING=1
 set CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
-set CORECLR_PROFILER_PATH=%BASE_PATH%OpenTelemetry.AutoInstrumentation.Native.dll
 set DOTNET_STARTUP_HOOKS=%BASE_PATH%OpenTelemetry.AutoInstrumentation.StartupHook.dll
 
 :: Settings for OpenTelemetry

--- a/src/Elastic.OpenTelemetry.AutoInstrumentation/_instrument.sh
+++ b/src/Elastic.OpenTelemetry.AutoInstrumentation/_instrument.sh
@@ -2,12 +2,64 @@
 
 BASE_PATH="$(cd "$(dirname "$0")" && pwd)"
 
+CORECLR_PROFILER_PATH="$(ls ${BASE_PATH}/OpenTelemetry.AutoInstrumentation.Native.* 2>/dev/null)"
+
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Unable to locate the native profiler inside current directory, possibly due to runtime identifier not being specified when building/publishing.
+Attempting to detect the runtime and use the native profiler from corresponding subdirectory of runtimes directory."
+
+  case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+    linux*)
+      if [ "$(ldd /bin/ls | grep -m1 'musl')" ]; then
+        OS_TYPE="linux-musl"
+      else
+        OS_TYPE="linux"
+      fi
+      FILE_EXTENSION=".so"
+      ;;
+    darwin*)
+      OS_TYPE="osx"
+      FILE_EXTENSION=".dylib"
+      ;;
+  esac
+
+  case "$OS_TYPE" in
+    "linux"|"linux-musl"|"osx")
+      ;;
+    *)
+      echo "Detected operating system type not supported." >&2
+      exit 1
+      ;;
+  esac
+
+  case $(uname -m) in
+    x86_64)  ARCHITECTURE="x64" ;;
+    aarch64) ARCHITECTURE="arm64" ;;
+  esac
+
+  case "$ARCHITECTURE" in
+    "x64"|"arm64")
+      ;;
+    *)
+      echo "Detected architecture not supported." >&2
+      exit 1
+      ;;
+  esac
+  CORECLR_PROFILER_PATH="${BASE_PATH}/runtimes/${OS_TYPE}-${ARCHITECTURE}/native/OpenTelemetry.AutoInstrumentation.Native${FILE_EXTENSION}"
+  if [ ! -f "${CORECLR_PROFILER_PATH}" ]; then
+    echo "Unable to locate the native profiler." >&2
+    exit 1
+  fi
+fi
+
+export CORECLR_PROFILER_PATH
+
 # Settings for .NET
 export ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper
 export CORECLR_ENABLE_PROFILING=1
 export CORECLR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
-CORECLR_PROFILER_PATH="$(ls ${BASE_PATH}/OpenTelemetry.AutoInstrumentation.Native.*)"
-export CORECLR_PROFILER_PATH
+
 export DOTNET_STARTUP_HOOKS=${BASE_PATH}/OpenTelemetry.AutoInstrumentation.StartupHook.dll
 
 # Settings for OpenTelemetry

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
@@ -47,7 +47,7 @@ internal static partial class LoggerMessages
 
 		logger.LogInformation("Process ID: {ProcessId}", process.Id);
 		logger.LogInformation("Process name: {ProcessName}", process.ProcessName);
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		logger.LogInformation("Process path: {ProcessPath}", Environment.ProcessPath);
 #else
 		logger.LogInformation("Process path: {ProcessPath}", "<Unknown>");

--- a/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
+++ b/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0</TargetFrameworks>
     <Title>Elastic Distribution of OpenTelemetry .NET</Title>
     <Description>OpenTelemetry extensions for Elastic Observability, fully native with zero code changes.</Description>
     <PackageTags>elastic;opentelemetry;observabillity;apm;logs;metrics;traces;monitoring</PackageTags>
@@ -29,9 +29,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
     <PackageReference Include="Polyfill" Version="7.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta09" PrivateAssets="all" ExcludeAssets="runtime" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2')) OR $(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Threading.Channels" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
+++ b/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0;net9.0</TargetFrameworks>
     <Title>Elastic Distribution of OpenTelemetry .NET</Title>
     <Description>OpenTelemetry extensions for Elastic Observability, fully native with zero code changes.</Description>
     <PackageTags>elastic;opentelemetry;observabillity;apm;logs;metrics;traces;monitoring</PackageTags>
@@ -19,20 +19,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
-    <PackageReference Include="Polyfill" Version="4.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Polyfill" Version="7.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta09" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2')) OR $(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Elastic.OpenTelemetry/ElasticOpenTelemetryBuilder.cs
+++ b/src/Elastic.OpenTelemetry/ElasticOpenTelemetryBuilder.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Reflection;
 using Elastic.OpenTelemetry.Configuration;
 using Elastic.OpenTelemetry.Diagnostics;
 using Elastic.OpenTelemetry.Diagnostics.Logging;
@@ -16,9 +15,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
-using static Elastic.OpenTelemetry.Configuration.ElasticOpenTelemetryOptions;
 
 namespace Elastic.OpenTelemetry;
 
@@ -169,10 +165,9 @@ internal static partial class LoggerMessages
 	[LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "No Elastic defaults were enabled.")]
 	public static partial void LogNoElasticDefaults(this ILogger logger);
 
-	[LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "ElasticOpenTelemetryBuilder {Signal} skipped, configured to be disabled")]
+	[LoggerMessage(EventId = 3, Level = LogLevel.Information, Message = "ElasticOpenTelemetryBuilder {Signal} skipped, configured to be disabled")]
 	public static partial void LogSignalDisabled(this ILogger logger, string signal);
 
-	[LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Elastic defaults for {Signal} skipped, configured to be disabled")]
+	[LoggerMessage(EventId = 4, Level = LogLevel.Information, Message = "Elastic defaults for {Signal} skipped, configured to be disabled")]
 	public static partial void LogDefaultsDisabled(this ILogger logger, string signal);
-
 }

--- a/src/Elastic.OpenTelemetry/Resources/HostDetector.cs
+++ b/src/Elastic.OpenTelemetry/Resources/HostDetector.cs
@@ -15,7 +15,7 @@ using System.Text;
 using Elastic.OpenTelemetry.SemanticConventions;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Resources;
-#if NETFRAMEWORK || NET6_0_OR_GREATER
+#if NETFRAMEWORK || NET8_0_OR_GREATER
 using Microsoft.Win32;
 #endif
 
@@ -145,7 +145,7 @@ internal sealed class HostDetector : IResourceDetector
 	// this type only exists in .NET 5+
 	private string? GetMachineIdWindows()
 	{
-#if NETFRAMEWORK || NET6_0_OR_GREATER
+#if NETFRAMEWORK || NET8_0_OR_GREATER
 		try
 		{
 			using var subKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography", false);

--- a/tests/AutoInstrumentation.IntegrationTests/AutoInstrumentation.IntegrationTests.csproj
+++ b/tests/AutoInstrumentation.IntegrationTests/AutoInstrumentation.IntegrationTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Elastic.OpenTelemetry.AutoInstrumentation.IntegrationTests</RootNamespace>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nullean.Xunit.Partitions" Version="0.5.0" />
-    <PackageReference Include="Testcontainers" Version="3.9.0"/>
+    <PackageReference Include="Testcontainers" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/AutoInstrumentation.IntegrationTests/ExampleApplicationContainer.cs
+++ b/tests/AutoInstrumentation.IntegrationTests/ExampleApplicationContainer.cs
@@ -50,7 +50,6 @@ public class ExampleApplicationContainer : IPartitionLifetime
 			.WithLogger(ConsoleLogger.Instance)
 			.WithOutputConsumer(_output)
 			.Build();
-
 	}
 
 	public async Task InitializeAsync()

--- a/tests/AutoInstrumentation.IntegrationTests/PluginLoaderTests.cs
+++ b/tests/AutoInstrumentation.IntegrationTests/PluginLoaderTests.cs
@@ -11,7 +11,6 @@ namespace Elastic.OpenTelemetry.AutoInstrumentation.IntegrationTests;
 
 public class PluginLoaderTests(ExampleApplicationContainer exampleApplicationContainer) : IPartitionFixture<ExampleApplicationContainer>
 {
-
 	[NotWindowsCiFact]
 	public async Task ObserveDistributionPluginLoad()
 	{
@@ -22,9 +21,7 @@ public class PluginLoaderTests(ExampleApplicationContainer exampleApplicationCon
 			.And.Contain("Elastic Distribution of OpenTelemetry .NET:")
 			.And.Contain("ElasticOpenTelemetryBuilder initialized")
 			.And.Contain("Added 'Elastic.OpenTelemetry.Processors.ElasticCompatibilityProcessor'");
-
 	}
-
 }
 
 public class NotWindowsCiFact : FactAttribute

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -22,17 +22,17 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(ProjectName), '^(.*)Tests$'))">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-    <PackageReference Include="JunitXml.TestLogger" Version="3.1.12" PrivateAssets="All" />
+    <PackageReference Include="JunitXml.TestLogger" Version="4.1.0" PrivateAssets="All" />
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.4.0" PrivateAssets="All" />
 
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.31.0" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1" />
     
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Elastic.OpenTelemetry.EndToEndTests/Elastic.OpenTelemetry.EndToEndTests.csproj
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/Elastic.OpenTelemetry.EndToEndTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.41.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.48.0" />
     <PackageReference Include="Nullean.Xunit.Partitions" Version="0.5.0" />
-    <PackageReference Include="Proc" Version="0.8.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Proc" Version="0.8.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Elastic.OpenTelemetry.Tests/Elastic.OpenTelemetry.Tests.csproj
+++ b/tests/Elastic.OpenTelemetry.Tests/Elastic.OpenTelemetry.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update to the .NET 9 SDK
- Update to OTel SDK 1.10
- Update all NuGet packages to the latest versions
- Update example to Aspire 9
- Update scripts as required