### PR TITLE
Refactor to use `AddOtlpExporter` and `LoggerProviderBuilder`

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -172,7 +172,7 @@ Valid options: `Critical`, `Error`, `Warning`, `Information`, `Debug`, `Trace` a
 * _Type_: Bool
 * _Default_: `false`
 
-Allows EDOT .NET to used with its defaults, but without enabling the export of telemetry data to
+Allows EDOT .NET to be used with its defaults, but without enabling the export of telemetry data to
 an OTLP endpoint. This can be useful when you want to test applications without sending telemetry data.
 
 | Configuration method | Key |

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.404",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestMajor",
+    "rollForward": "latestMinor",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestMinor",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/src/Elastic.OpenTelemetry/Extensions/LoggingProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/LoggingProviderBuilderExtensions.cs
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Trace;
+using static Elastic.OpenTelemetry.Configuration.Signals;
+
+namespace Elastic.OpenTelemetry.Extensions;
+
+/// <summary>
+/// Elastic extensions for <see cref="LoggerProviderBuilder"/>.
+/// </summary>
+public static class LoggingProviderBuilderExtensions
+{
+	/// <summary>
+	/// Use Elastic Distribution of OpenTelemetry .NET defaults for <see cref="LoggerProviderBuilder"/>.
+	/// </summary>
+	public static LoggerProviderBuilder UseElasticDefaults(this LoggerProviderBuilder builder, bool skipOtlp = false, ILogger? logger = null)
+	{
+		logger ??= NullLogger.Instance;
+
+		if (!skipOtlp)
+			builder.AddOtlpExporter();
+
+		logger.LogConfiguredSignalProvider(nameof(Logs), nameof(LoggerProviderBuilder));
+		return builder;
+	}
+}

--- a/src/Elastic.OpenTelemetry/Extensions/MeterProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/MeterProviderBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Elastic.OpenTelemetry.Extensions;
 public static class MeterProviderBuilderExtensions
 {
 	/// <summary> Use Elastic Distribution of OpenTelemetry .NET defaults for <see cref="MeterProviderBuilder"/> </summary>
-	public static MeterProviderBuilder UseElasticDefaults(this MeterProviderBuilder builder, ILogger? logger = null)
+	public static MeterProviderBuilder UseElasticDefaults(this MeterProviderBuilder builder, bool skipOtlp = false, ILogger? logger = null)
 	{
 		logger ??= NullLogger.Instance;
 
@@ -23,6 +23,9 @@ public static class MeterProviderBuilderExtensions
 			.AddProcessInstrumentation()
 			.AddRuntimeInstrumentation()
 			.AddHttpClientInstrumentation();
+
+		if (!skipOtlp)
+			builder.AddOtlpExporter();
 
 		logger.LogConfiguredSignalProvider(nameof(Metrics), nameof(MeterProviderBuilder));
 

--- a/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
@@ -8,12 +8,15 @@ using Elastic.OpenTelemetry.Processors;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
 using static Elastic.OpenTelemetry.Configuration.Signals;
 
 namespace Elastic.OpenTelemetry.Extensions;
 
-/// <summary> Elastic extensions for <see cref="TracerProviderBuilder"/>. </summary>
+/// <summary>
+/// Elastic extensions for <see cref="TracerProviderBuilder"/>.
+/// </summary>
 public static class TracerProviderBuilderExtensions
 {
 	/// <summary>
@@ -34,17 +37,23 @@ public static class TracerProviderBuilderExtensions
 		return builder.AddProcessor(processor);
 	}
 
-	/// <summary> Use Elastic Distribution of OpenTelemetry .NET defaults for <see cref="TracerProviderBuilder"/> </summary>
-	public static TracerProviderBuilder UseElasticDefaults(this TracerProviderBuilder builder, ILogger? logger = null)
+	/// <summary>
+	/// Use Elastic Distribution of OpenTelemetry .NET defaults for <see cref="TracerProviderBuilder"/>.
+	/// </summary>
+	public static TracerProviderBuilder UseElasticDefaults(this TracerProviderBuilder builder, bool skipOtlp = false, ILogger? logger = null)
 	{
 		logger ??= NullLogger.Instance;
 
 		builder
 			.AddHttpClientInstrumentation()
 			.AddGrpcClientInstrumentation()
-			.AddEntityFrameworkCoreInstrumentation();
+			.AddEntityFrameworkCoreInstrumentation()
+			.AddSource("Elastic.Transport")
+			.AddElasticProcessors(logger);
 
-		builder.AddElasticProcessors(logger);
+		if (!skipOtlp)
+			builder.AddOtlpExporter();
+
 		logger.LogConfiguredSignalProvider(nameof(Traces), nameof(TracerProviderBuilder));
 		return builder;
 	}


### PR DESCRIPTION
We initially used UseOtlpExporter as a convenient way to enable OTLP export by default globally for all signals. However, this plays poorly with the AddOtlpExporter methods, which throw if called by consumer code. This change avoids that risk. It also introduces a LoggingProviderBuilder extension to register our defaults, which our main builder calls.

We still support disabling our default registration of the OTLP exporter via an environment variable, which the auto instrumentation plugin then passes when configuring the providers.

This PR also fixes a small typo in the docs.

Closes #177