### PR TITLE
ci(e2e): use the QA environment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   # (keep_serverless-staging-oblt, keep_serverless-qa-oblt or serverless-production-oblt)
-  SERVERLESS_PROJECT: serverless-production-oblt
+  SERVERLESS_PROJECT: keep_serverless-qa-oblt
 
 # NOTE: if you add a new job and it's a mandatory check then
 #       update e2e-docs.yml
@@ -64,8 +64,8 @@ jobs:
         with:
           export_to_environment: true
           secrets: |-
-            E2E__BROWSEREMAIL:elastic-observability/elastic-cloud-observability-team-pro-username
-            E2E__BROWSERPASSWORD:elastic-observability/elastic-cloud-observability-team-pro-password
+            E2E__BROWSEREMAIL:elastic-observability/elastic-cloud-observability-team-qa-username
+            E2E__BROWSERPASSWORD:elastic-observability/elastic-cloud-observability-team-qa-password
 
       - name: End-to-end tests
         run: ./build.sh test --test-suite=e2e


### PR DESCRIPTION
### What
Run e2e targetting QA

### Why
`QA` is a long-running environment
`QA` is more aimed for testing against to


Test: https://github.com/elastic/elastic-otel-dotnet/actions/runs/11974026009?pr=185

