### PR TITLE
Enable additional default instrumentation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,5 +78,5 @@ jobs:
         if: always()
         with:
           name: playwright-traces
-          path: .artifacts/playwright-traces/*-screenshot.jpeg
+          path: .artifacts/playwright-traces/*
           retention-days: 1

--- a/build/scripts/Packaging.fs
+++ b/build/scripts/Packaging.fs
@@ -80,7 +80,7 @@ let downloadArtifacts (_:ParseResults<Build>) =
             async {
                 Console.WriteLine($"Retrieving {asset.Name}");
                 let! fileData = httpClient.GetByteArrayAsync(asset.BrowserDownloadUrl) |> Async.AwaitTask
-                Console.WriteLine($"Saveing %i{fileData.Length} bytes to {f.FullName}")
+                Console.WriteLine($"Saving %i{fileData.Length} bytes to {f.FullName}")
                 File.WriteAllBytes(f.FullName, fileData)
                 f.Refresh()
             } |> Async.RunSynchronously

--- a/examples/Example.AutoInstrumentation/README.md
+++ b/examples/Example.AutoInstrumentation/README.md
@@ -2,7 +2,7 @@
 
 This is a very minimal .NET application that we use to validate our OpenTelemetry plugin loads correctly
 
-This happens automated through our testing setup:
+This happens automatically through our testing setup:
 
 ```bash
 $ ./build.sh test --test-suite=integration
@@ -10,17 +10,14 @@ $ ./build.sh test --test-suite=integration
 
 Which ends up running the tests in `/tests/AutoInstrumentation.IntegrationTests`
 
-
-To quickly see the `DockerFile`  in action run the following from the root of this repository.
-
+To quickly see the `DockerFile` in action run the following from the root of this repository.
 
 ```bash
 $ docker build -t example.autoinstrumentation:latest -f examples/Example.AutoInstrumentation/Dockerfile --no-cache . && \
-   docker run -it --rm -p 5000:8080 --name autoin example.autoinstrumentation:latest
+    docker run -it --rm -p 5000:8080 --name autoin example.autoinstrumentation:latest
 ```
-
 
 ```bash
 docker build -t distribution.autoinstrumentation:latest -f examples/Example.AutoInstrumentation/distribution.Dockerfile --platform linux/arm64 --no-cache . && \
-         docker run -it --rm -p 5000:8080 --name distri --platform linux/arm64 distribution.autoinstrumentation:latest
+    docker run -it --rm -p 5000:8080 --name distri --platform linux/arm64 distribution.autoinstrumentation:latest
 ```

--- a/src/Elastic.OpenTelemetry/AutoInstrumentationPlugin.cs
+++ b/src/Elastic.OpenTelemetry/AutoInstrumentationPlugin.cs
@@ -52,7 +52,7 @@ public class AutoInstrumentationPlugin
 
 	/// To configure tracing SDK before Auto Instrumentation configured SDK
 	public TracerProviderBuilder BeforeConfigureTracerProvider(TracerProviderBuilder builder) =>
-		builder.UseElasticDefaults(_skipOtlp, _logger);
+		builder.UseAutoInstrumentationElasticDefaults(_skipOtlp, _logger);
 
 	/// To configure tracing SDK after Auto Instrumentation configured SDK
 	public TracerProviderBuilder AfterConfigureTracerProvider(TracerProviderBuilder builder) =>

--- a/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
+++ b/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
@@ -22,13 +22,16 @@
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
-    <PackageReference Include="Polyfill" Version="4.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
+    <PackageReference Include="Polyfill" Version="7.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta09" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2')) OR $(TargetFramework.StartsWith('net4'))">

--- a/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
@@ -48,6 +48,8 @@ public static class TracerProviderBuilderExtensions
 			.AddHttpClientInstrumentation()
 			.AddGrpcClientInstrumentation()
 			.AddEntityFrameworkCoreInstrumentation()
+			.AddElasticsearchClientInstrumentation()
+			.AddSqlClientInstrumentation()
 			.AddSource("Elastic.Transport")
 			.AddElasticProcessors(logger);
 

--- a/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
@@ -59,4 +59,19 @@ public static class TracerProviderBuilderExtensions
 		logger.LogConfiguredSignalProvider(nameof(Traces), nameof(TracerProviderBuilder));
 		return builder;
 	}
+
+	internal static TracerProviderBuilder UseAutoInstrumentationElasticDefaults(this TracerProviderBuilder builder, bool skipOtlp = false, ILogger? logger = null)
+	{
+		logger ??= NullLogger.Instance;
+
+		builder
+			.AddSource("Elastic.Transport")
+			.AddElasticProcessors(logger);
+
+		if (!skipOtlp)
+			builder.AddOtlpExporter();
+
+		logger.LogConfiguredSignalProvider(nameof(Traces), nameof(TracerProviderBuilder));
+		return builder;
+	}
 }

--- a/tests/Elastic.OpenTelemetry.EndToEndTests/ServiceTests.cs
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/ServiceTests.cs
@@ -34,7 +34,6 @@ public class EndToEndTests(ITestOutputHelper output, DistributedApplicationFixtu
 			.ToBeVisibleAsync(new() { Timeout = timeout });
 	}
 
-
 	public async Task InitializeAsync() => _page = await fixture.ApmUI.NewProfiledPage(_testName);
 
 	public async Task DisposeAsync()
@@ -45,6 +44,6 @@ public class EndToEndTests(ITestOutputHelper output, DistributedApplicationFixtu
 		if (success)
 			return;
 
-		DotNetRunApplication.IterateOverLog(Output.WriteLine);
+		fixture.WriteFailureTestOutput(Output);
 	}
 }


### PR DESCRIPTION
Closes #123

Enables a default set of instrumentations when using the NuGet-based install method. For auto-instrumentation, we currently only enable the instrumentations shipped in the OTel auto instrumentation zip (i.e., Not `OpenTelemetry.Instrumentation.ElasticsearchClient`). We will review those once they are stable and potentially manually pull them into our customised zip files.

This also extended the retries for E2E, so hopefully, they will be less brittle in CI. It also takes additional screenshots, which help verify the Apm UI during E2E tests.