### PR TITLE
Small docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ NuGet package to your project. This can be achieved by adding the package refere
 
 ## Read the docs
 
-* [Get started](./get-started.md)
-* [Configuration](./configure.md)
+* [Get started](./docs/get-started.md)
+* [Configuration](./docs/configure.md)
 
 <!-- ## Getting started
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -95,8 +95,8 @@ host-based applications like [worker services](https://learn.microsoft.com/en-us
 1. Inside the `Program.cs` file of the ASP.NET Core application, add the following two `using` directives:
 
     ```csharp
-using OpenTelemetry;
-using OpenTelemetry.Trace;
+    using OpenTelemetry;
+    using OpenTelemetry.Trace;
     ```
 
     The OpenTelemetry SDK provides extension methods on the `IServiceCollection` to enable the providers and configure the SDK. EDOT .NET overrides the default OpenTelemetry SDK registration, adding several opinionated defaults.
@@ -104,19 +104,19 @@ using OpenTelemetry.Trace;
 1. In the minimal API template, the `WebApplicationBuilder` exposes a `Services` property that can be used to register services with the dependency injection container. To enable tracing and metrics collection, ensure that the OpenTelemetry SDK is registered:
 
     ```csharp
-var builder = WebApplication.CreateBuilder(args);
+    var builder = WebApplication.CreateBuilder(args);
 
-builder.Services
-	// The `AddHttpClient` method registers the `IHttpClientFactory` service with
-	// the dependency injection container. This is NOT required to enable OpenTelemetry,
-	// but the example endpoint will use it to send an HTTP request.
-	.AddHttpClient()
-	// The `AddOpenTelemetry` method registers the OpenTelemetry SDK with the
-	// dependency injection container. When available, EDOT .NET will override
-	// this to add opinionated defaults.
-	.AddOpenTelemetry()
-	// Configure tracing to instrument requests handled by ASP.NET Core.
-	.WithTracing(t => t.AddAspNetCoreInstrumentation());
+    builder.Services
+      // The `AddHttpClient` method registers the `IHttpClientFactory` service with
+      // the dependency injection container. This is NOT required to enable OpenTelemetry,
+      // but the example endpoint will use it to send an HTTP request.
+      .AddHttpClient()
+      // The `AddOpenTelemetry` method registers the OpenTelemetry SDK with the
+      // dependency injection container. When available, EDOT .NET will override
+      // this to add opinionated defaults.
+      .AddOpenTelemetry()
+      // Configure tracing to instrument requests handled by ASP.NET Core.
+      .WithTracing(t => t.AddAspNetCoreInstrumentation());
     ```
 
 With these limited changes to the `Program.cs` file, the application is now configured to use the

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -211,8 +211,8 @@ You can find the values of these variables in Kibana's APM tutorial. In Kibana:
     For example:
 
     ```sh
-export OTEL_EXPORTER_OTLP_ENDPOINT=https://my-deployment.apm.us-west1.gcp.cloud.es.io
-export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer P....l"
+    export OTEL_EXPORTER_OTLP_ENDPOINT=https://my-deployment.apm.us-west1.gcp.cloud.es.io
+    export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer P....l"
     ```
 1. Configure environment variables for the application either in `launchSettings.json` or in the environment where the application is running.
 1. Once configured, run the application and make a request to the root endpoint. A trace will be generated and exported to the OTLP endpoint.


### PR DESCRIPTION
This PR, if applied will
- Fix the links from the primary readme to the docs
- Fix the indentation in the code blocks in `get-started.md`