### PR TITLE
Use native .NET 9 traces and metrics for HTTP instrumentation

### DIFF
--- a/examples/Example.AspNetCore.Mvc/Controllers/HomeController.cs
+++ b/examples/Example.AspNetCore.Mvc/Controllers/HomeController.cs
@@ -14,9 +14,11 @@ public class HomeController(IHttpClientFactory httpClientFactory) : Controller
 	public const string ActivitySourceName = "CustomActivitySource";
 	private static readonly ActivitySource ActivitySource = new(ActivitySourceName, "1.0.0");
 
+	private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
+
 	public async Task<IActionResult> Index()
 	{
-		using var client = httpClientFactory.CreateClient();
+		using var client = _httpClientFactory.CreateClient();
 
 		// ReSharper disable once ExplicitCallerInfoArgument
 		using var activity = ActivitySource.StartActivity("DoingStuff", ActivityKind.Internal);

--- a/examples/Example.AspNetCore.Mvc/Program.cs
+++ b/examples/Example.AspNetCore.Mvc/Program.cs
@@ -16,13 +16,12 @@ var logger = loggerFactory.CreateLogger("OpenTelemetry");
 // Add services to the container.
 builder.Services
 	.AddHttpClient()
-	.AddOpenTelemetry()
-	.ConfigureResource(r => r.AddService("MyNewService1"))
-	.WithElasticDefaults(builder.Configuration);
+	.AddElasticOpenTelemetry(builder.Configuration, logger)
+	.ConfigureResource(r => r.AddService("MyNewService1"));
 
-builder.Services.AddOpenTelemetry()
-	.ConfigureResource(r => r.AddService("MyNewService2"))
-	.WithElasticDefaults(builder.Configuration);
+//builder.Services.AddOpenTelemetry()
+//	.ConfigureResource(r => r.AddService("MyNewService2"))
+//	.WithElasticDefaults(builder.Configuration);
 
 //OpenTelemetrySdk.Create(b => b.WithElasticDefaults(builder.Configuration));
 

--- a/examples/ServiceDefaults/ServiceDefaults.csproj
+++ b/examples/ServiceDefaults/ServiceDefaults.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.1" />
-    <!--<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />-->
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
   </ItemGroup>

--- a/examples/ServiceDefaults/ServiceDefaults.csproj
+++ b/examples/ServiceDefaults/ServiceDefaults.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
@@ -16,7 +16,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <!--<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />-->
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
   </ItemGroup>

--- a/src/Elastic.OpenTelemetry/Core/SignalBuilder.cs
+++ b/src/Elastic.OpenTelemetry/Core/SignalBuilder.cs
@@ -37,7 +37,6 @@ internal static class SignalBuilder
 		// code in this particular case by shortcutting and returning early.
 		if (options is not null && components is not null)
 		{
-			ValidateGlobalCallCount(methodName, builderName, options, components, callCount);
 			configure(builder, components);
 			return true;
 		}

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
@@ -39,6 +39,10 @@ internal static partial class LoggerMessages
 	[LoggerMessage(EventId = 9, EventName = "AddedInstrumentation", Level = LogLevel.Information, Message = "Added {InstrumentationName} to {Provider}.")]
 	public static partial void LogAddedInstrumentation(this ILogger logger, string instrumentationName, string provider);
 
+	[LoggerMessage(EventId = 10, EventName = "HttpInstrumentationFound", Level = LogLevel.Information, Message = "The HTTP instrumentation library was located at '{AssemblyPath}'. " +
+		"Skipping adding native {InstrumentationType} instrumentation from the 'System.Net.Http' ActivitySource.")]
+	public static partial void LogHttpInstrumentationFound(this ILogger logger, string assemblyPath, string instrumentationType);
+
 	// We explictly reuse the same event ID and this is the same log message, but with different types for the structured data
 	[LoggerMessage(EventId = 9, Level = LogLevel.Debug, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void FoundTag(this ILogger logger, string processorName, string attributeName, string attributeValue);

--- a/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
+++ b/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -24,7 +24,6 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
@@ -32,15 +31,16 @@
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.11.0-beta.1" />
     <PackageReference Include="Polyfill" Version="7.16.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta09" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2')) OR $(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Threading.Channels" Version="9.0.1" />
+    <PackageReference Include="System.Threading.Channels" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
On .NET 9, the BCL includes OTel-compliant instrumentation for HTTP, which is now preferred over using the contrib instrumentation. For .NET 9+ targets, we check if the contrib library is referenced, and if so, load that via reflection. Otherwise, we register the System.Net.Http source.

Closes #195