### PR TITLE
Remove use of FluentAssertions

### DIFF
--- a/tests/AutoInstrumentation.IntegrationTests/PluginLoaderTests.cs
+++ b/tests/AutoInstrumentation.IntegrationTests/PluginLoaderTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System.Runtime.InteropServices;
-using FluentAssertions;
 using Nullean.Xunit.Partitions.Sdk;
 using Xunit;
 
@@ -15,12 +14,13 @@ public class PluginLoaderTests(ExampleApplicationContainer exampleApplicationCon
 	public async Task ObserveDistributionPluginLoad()
 	{
 		await Task.Delay(TimeSpan.FromSeconds(3));
+
 		var output = exampleApplicationContainer.FailureTestOutput();
-		output.Should()
-			.NotBeNullOrWhiteSpace()
-			.And.Contain("Elastic Distribution of OpenTelemetry .NET:")
-			.And.Contain("ElasticOpenTelemetryBuilder initialized")
-			.And.Contain("Added 'Elastic.OpenTelemetry.Processors.ElasticCompatibilityProcessor'");
+
+		Assert.False(string.IsNullOrWhiteSpace(output));
+		Assert.Contains("Elastic Distribution of OpenTelemetry (EDOT) .NET:", output);
+		Assert.Contains("ElasticOpenTelemetryBuilder initialized", output);
+		Assert.Contains("Added 'Elastic.OpenTelemetry.Processors.ElasticCompatibilityProcessor'", output);
 	}
 }
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -22,17 +22,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(ProjectName), '^(.*)Tests$'))">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.1.12" PrivateAssets="All" />
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.4.0" PrivateAssets="All" />
-
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.31.0" />
-    
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/ITrafficSimulator.cs
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/DistributedFixture/ITrafficSimulator.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Net;
-using FluentAssertions;
+using Xunit;
 
 namespace Elastic.OpenTelemetry.EndToEndTests.DistributedFixture;
 
@@ -19,7 +19,7 @@ public class DefaultTrafficSimulator : ITrafficSimulator
 		for (var i = 0; i < 10; i++)
 		{
 			var get = await distributedInfra.AspNetApplication.HttpClient.GetAsync("e2e");
-			get.StatusCode.Should().Be(HttpStatusCode.OK);
+			Assert.Equal(HttpStatusCode.OK, get.StatusCode);
 			_ = await get.Content.ReadAsStringAsync();
 		}
 	}

--- a/tests/Elastic.OpenTelemetry.EndToEndTests/Elastic.OpenTelemetry.EndToEndTests.csproj
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/Elastic.OpenTelemetry.EndToEndTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageReference Include="Nullean.Xunit.Partitions" Version="0.5.0" />
-    <PackageReference Include="Proc" Version="0.8.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageReference Include="Proc" Version="0.9.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/Elastic.OpenTelemetry.EndToEndTests/EndToEndOptions.cs
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/EndToEndOptions.cs
@@ -4,7 +4,6 @@
 
 using Elastic.OpenTelemetry.EndToEndTests;
 using Elastic.OpenTelemetry.EndToEndTests.DistributedFixture;
-using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Nullean.Xunit.Partitions;
 using Xunit;
@@ -29,19 +28,15 @@ public class EndToEndOptions : PartitionOptions
 		if (testSuite == null || (
 				!testSuite.Equals("e2e", StringComparison.InvariantCultureIgnoreCase)
 				&& !testSuite.Equals("all", StringComparison.InvariantCultureIgnoreCase))
-			)
+		)
 			return;
 
 		try
 		{
-			configuration["E2E:Endpoint"].Should()
-				.NotBeNullOrWhiteSpace("Missing E2E:Endpoint configuration");
-			configuration["E2E:Authorization"].Should()
-				.NotBeNullOrWhiteSpace("Missing E2E:Authorization configuration");
-			configuration["E2E:BrowserEmail"].Should()
-				.NotBeNullOrWhiteSpace("Missing E2E:BrowserEmail configuration");
-			configuration["E2E:BrowserPassword"].Should()
-				.NotBeNullOrWhiteSpace("Missing E2E:BrowserPassword configuration");
+			Assert.False(string.IsNullOrWhiteSpace(configuration["E2E:Endpoint"]), userMessage: "Missing E2E:Endpoint configuration");
+			Assert.False(string.IsNullOrWhiteSpace(configuration["E2E:Authorization"]), userMessage: "Missing E2E:Authorization configuration");
+			Assert.False(string.IsNullOrWhiteSpace(configuration["E2E:BrowserEmail"]), userMessage: "Missing E2E:BrowserEmail configuration");
+			Assert.False(string.IsNullOrWhiteSpace(configuration["E2E:BrowserPassword"]), userMessage: "Missing E2E:BrowserPassword configuration");
 		}
 		catch (Exception e)
 		{

--- a/tests/Elastic.OpenTelemetry.EndToEndTests/ServiceTests.cs
+++ b/tests/Elastic.OpenTelemetry.EndToEndTests/ServiceTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.OpenTelemetry.EndToEndTests.DistributedFixture;
-using FluentAssertions;
 using Microsoft.Playwright;
 using Nullean.Xunit.Partitions.Sdk;
 using Xunit;
@@ -20,7 +19,7 @@ public class EndToEndTests(ITestOutputHelper output, DistributedApplicationFixtu
 	private IPage _page = null!;
 
 	[Fact]
-	public void EnsureApplicationWasStarted() => fixture.Started.Should().BeTrue();
+	public void EnsureApplicationWasStarted() => Assert.True(fixture.Started);
 
 	[Fact]
 	public async Task LatencyShowsAGraph()

--- a/tests/Elastic.OpenTelemetry.Tests/AutoInstrumentationPluginTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/AutoInstrumentationPluginTests.cs
@@ -16,8 +16,8 @@ public class AutoInstrumentationPluginTests
 
 		var error = sut.GetErrorText();
 
-		error.Should().StartWith("Unable to bootstrap EDOT .NET due to");
-		error.Should().Contain(TestableAutoInstrumentationPlugin.ExceptionMessage);
+		Assert.StartsWith("Unable to bootstrap EDOT .NET due to", error);
+		Assert.Contains(TestableAutoInstrumentationPlugin.ExceptionMessage, error);
 	}
 
 	private class TestableAutoInstrumentationPlugin : AutoInstrumentationPlugin

--- a/tests/Elastic.OpenTelemetry.Tests/Configuration/ElasticOpenTelemetryOptionsTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Configuration/ElasticOpenTelemetryOptionsTests.cs
@@ -29,20 +29,22 @@ public sealed class ElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 			{ ELASTIC_OTEL_SKIP_OTLP_EXPORTER, null },
 		});
 
-		sut.GlobalLogEnabled.Should().Be(false);
-		// these default to null because any other value would enable file logging
-		sut.LogDirectory.Should().Be(sut.LogDirectoryDefault);
-		sut.LogLevel.Should().Be(LogLevel.Warning);
+		Assert.False(sut.GlobalLogEnabled);
 
-		sut.SkipOtlpExporter.Should().Be(false);
+		// these default to null because any other value would enable file logging
+		Assert.Equal(sut.LogDirectoryDefault, sut.LogDirectory);
+		Assert.Equal(LogLevel.Warning, sut.LogLevel);
+
+		Assert.False(sut.SkipOtlpExporter);
 
 		var logger = new TestLogger(output);
 
 		sut.LogConfigSources(logger);
 
-		logger.Messages.Count.Should().Be(ExpectedLogsLength);
+		Assert.Equal(ExpectedLogsLength, logger.Messages.Count);
+
 		foreach (var message in logger.Messages)
-			message.Should().EndWith("from [Default]");
+			Assert.EndsWith("from [Default]", message);
 	}
 
 	[Fact]
@@ -58,18 +60,17 @@ public sealed class ElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 			{ ELASTIC_OTEL_SKIP_OTLP_EXPORTER, "true" },
 		});
 
-		sut.LogDirectory.Should().Be(fileLogDirectory);
-		sut.LogLevel.Should().Be(ToLogLevel(fileLogLevel));
-		sut.SkipOtlpExporter.Should().Be(true);
+		Assert.Equal(fileLogDirectory, sut.LogDirectory);
+		Assert.Equal(ToLogLevel(fileLogLevel), sut.LogLevel);
+		Assert.True(sut.SkipOtlpExporter);
 
 		var logger = new TestLogger(output);
 
 		sut.LogConfigSources(logger);
 
-		logger.Messages.Should()
-			.Contain(s => s.EndsWith("from [Environment]"))
-			.And.Contain(s => s.EndsWith("from [Default]"))
-			.And.NotContain(s => s.EndsWith("from [IConfiguration]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [Environment]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [Default]"));
+		Assert.DoesNotContain(logger.Messages, s => s.EndsWith("from [IConfiguration]"));
 	}
 
 	[Fact]
@@ -104,21 +105,21 @@ public sealed class ElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 
 		var sut = new CompositeElasticOpenTelemetryOptions(config, new Hashtable());
 
-		sut.LogDirectory.Should().Be(@"C:\Temp");
-		sut.LogLevel.Should().Be(ToLogLevel(fileLogLevel));
-		sut.SkipOtlpExporter.Should().Be(true);
-		sut.EventLogLevel.Should().Be(EventLevel.Warning);
-		sut.LogLevel.Should().Be(LogLevel.Critical);
+		Assert.Equal(@"C:\Temp", sut.LogDirectory);
+		Assert.Equal(ToLogLevel(fileLogLevel), sut.LogLevel);
+		Assert.True(sut.SkipOtlpExporter);
+		Assert.Equal(EventLevel.Warning, sut.EventLogLevel);
+		Assert.Equal(LogLevel.Critical, sut.LogLevel);
 
 		var logger = new TestLogger(output);
 
 		sut.LogConfigSources(logger);
 
-		logger.Messages.Count.Should().Be(ExpectedLogsLength);
-		logger.Messages.Should()
-			.Contain(s => s.EndsWith("from [IConfiguration]"))
-			.And.Contain(s => s.EndsWith("from [Default]"))
-			.And.NotContain(s => s.EndsWith("from [Environment]"));
+		Assert.Equal(ExpectedLogsLength, logger.Messages.Count);
+
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [IConfiguration]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [Default]"));
+		Assert.DoesNotContain(logger.Messages, s => s.EndsWith("from [Environment]"));
 	}
 
 	[Fact]
@@ -151,20 +152,19 @@ public sealed class ElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 
 		var sut = new CompositeElasticOpenTelemetryOptions(config, new Hashtable());
 
-		sut.LogDirectory.Should().Be(@"C:\Temp");
-		sut.LogLevel.Should().Be(ToLogLevel(loggingSectionLogLevel));
-		sut.SkipOtlpExporter.Should().Be(true);
-		sut.LogLevel.Should().Be(LogLevel.Warning);
-		sut.EventLogLevel.Should().Be(EventLevel.Warning);
+		Assert.Equal(@"C:\Temp", sut.LogDirectory);
+		Assert.Equal(ToLogLevel(loggingSectionLogLevel), sut.LogLevel);
+		Assert.True(sut.SkipOtlpExporter);
+		Assert.Equal(EventLevel.Warning, sut.EventLogLevel);
+		Assert.Equal(LogLevel.Warning, sut.LogLevel);
 
 		var logger = new TestLogger(output);
 
 		sut.LogConfigSources(logger);
 
-		logger.Messages.Should()
-			.Contain(s => s.EndsWith("from [IConfiguration]"))
-			.And.Contain(s => s.EndsWith("from [Default]"))
-			.And.NotContain(s => s.EndsWith("from [Environment]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [IConfiguration]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [Default]"));
+		Assert.DoesNotContain(logger.Messages, s => s.EndsWith("from [Environment]"));
 	}
 
 	[Fact]
@@ -196,19 +196,18 @@ public sealed class ElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 
 		var sut = new CompositeElasticOpenTelemetryOptions(config, new Hashtable());
 
-		sut.LogDirectory.Should().Be(@"C:\Temp");
-		sut.LogLevel.Should().Be(ToLogLevel(loggingSectionDefaultLogLevel));
-		sut.SkipOtlpExporter.Should().Be(true);
-		sut.EventLogLevel.Should().Be(EventLevel.Informational);
+		Assert.Equal(@"C:\Temp", sut.LogDirectory);
+		Assert.Equal(ToLogLevel(loggingSectionDefaultLogLevel), sut.LogLevel);
+		Assert.True(sut.SkipOtlpExporter);
+		Assert.Equal(EventLevel.Informational, sut.EventLogLevel);
 
 		var logger = new TestLogger(output);
 
 		sut.LogConfigSources(logger);
 
-		logger.Messages.Should()
-			.Contain(s => s.EndsWith("from [IConfiguration]"))
-			.And.Contain(s => s.EndsWith("from [Default]"))
-			.And.NotContain(s => s.EndsWith("from [Environment]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [IConfiguration]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [Default]"));
+		Assert.DoesNotContain(logger.Messages, s => s.EndsWith("from [Environment]"));
 	}
 
 	[Fact]
@@ -241,9 +240,10 @@ public sealed class ElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 			{ ELASTIC_OTEL_SKIP_OTLP_EXPORTER, "true" },
 		});
 
-		sut.LogDirectory.Should().Be(fileLogDirectory);
-		sut.LogLevel.Should().Be(ToLogLevel(fileLogLevel));
-		sut.SkipOtlpExporter.Should().Be(true);
+		Assert.Equal(fileLogDirectory, sut.LogDirectory);
+		Assert.Equal(ToLogLevel(fileLogLevel), sut.LogLevel);
+		Assert.True(sut.SkipOtlpExporter);
+
 	}
 
 	[Fact]
@@ -264,17 +264,16 @@ public sealed class ElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 			SkipOtlpExporter = false,
 		};
 
-		sut.LogDirectory.Should().Be(fileLogDirectory);
-		sut.LogLevel.Should().Be(ToLogLevel(fileLogLevel));
-		sut.SkipOtlpExporter.Should().Be(false);
+		Assert.Equal(fileLogDirectory, sut.LogDirectory);
+		Assert.Equal(ToLogLevel(fileLogLevel), sut.LogLevel);
+		Assert.False(sut.SkipOtlpExporter);
 
 		var logger = new TestLogger(output);
 
 		sut.LogConfigSources(logger);
 
-		logger.Messages.Should()
-			.Contain(s => s.EndsWith("from [Property]"))
-			.And.Contain(s => s.EndsWith("from [Default]"))
-			.And.NotContain(s => s.EndsWith("from [Environment]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [Property]"));
+		Assert.Contains(logger.Messages, s => s.EndsWith("from [Default]"));
+		Assert.DoesNotContain(logger.Messages, s => s.EndsWith("from [Environment]"));
 	}
 }

--- a/tests/Elastic.OpenTelemetry.Tests/Configuration/GlobalLogConfigurationTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Configuration/GlobalLogConfigurationTests.cs
@@ -15,10 +15,11 @@ public class GlobalLogConfigurationTests
 	public void Check_Defaults()
 	{
 		var config = new CompositeElasticOpenTelemetryOptions(new Hashtable());
-		config.GlobalLogEnabled.Should().BeFalse();
-		config.LogLevel.Should().Be(LogLevel.Warning);
-		config.LogDirectory.Should().Be(config.LogDirectoryDefault);
-		config.LogTargets.Should().Be(LogTargets.None);
+
+		Assert.False(config.GlobalLogEnabled);
+		Assert.Equal(LogLevel.Warning, config.LogLevel);
+		Assert.Equal(config.LogDirectoryDefault, config.LogDirectory);
+		Assert.Equal(LogTargets.None, config.LogTargets);
 	}
 
 	//
@@ -30,8 +31,9 @@ public class GlobalLogConfigurationTests
 	public void CheckActivation(string environmentVariable, string value)
 	{
 		var config = new CompositeElasticOpenTelemetryOptions(new Hashtable { { environmentVariable, value } });
-		config.GlobalLogEnabled.Should().BeTrue();
-		config.LogTargets.Should().Be(LogTargets.File);
+
+		Assert.True(config.GlobalLogEnabled);
+		Assert.Equal(LogTargets.File, config.LogTargets);
 	}
 
 	//
@@ -47,8 +49,9 @@ public class GlobalLogConfigurationTests
 			{ OTEL_DOTNET_AUTO_LOG_DIRECTORY, "" },
 			{ environmentVariable, value }
 		});
-		config.GlobalLogEnabled.Should().BeFalse();
-		config.LogTargets.Should().Be(LogTargets.None);
+
+		Assert.False(config.GlobalLogEnabled);
+		Assert.Equal(LogTargets.None, config.LogTargets);
 	}
 
 	[Theory]
@@ -60,7 +63,7 @@ public class GlobalLogConfigurationTests
 	public void CheckNonActivation(string environmentVariable, string value)
 	{
 		var config = new CompositeElasticOpenTelemetryOptions(new Hashtable { { environmentVariable, value } });
-		config.GlobalLogEnabled.Should().BeFalse();
+		Assert.False(config.GlobalLogEnabled);
 	}
 
 	[Theory]
@@ -80,8 +83,9 @@ public class GlobalLogConfigurationTests
 		static void Check(string key, string envVarValue, LogLevel level, bool enabled)
 		{
 			var config = CreateConfig(key, envVarValue);
-			config.LogLevel.Should().Be(level, "{0}", key);
-			config.GlobalLogEnabled.Should().Be(enabled, "{0}", key);
+
+			Assert.Equal(enabled, config.GlobalLogEnabled);
+			Assert.Equal(level, config.LogLevel);
 		}
 	}
 
@@ -98,7 +102,7 @@ public class GlobalLogConfigurationTests
 		static void Check(string key, string? envVarValue)
 		{
 			var config = CreateConfig(key, envVarValue);
-			config.LogLevel.Should().Be(LogLevel.Warning, "{0}", key);
+			Assert.Equal(LogLevel.Warning, config.LogLevel);
 		}
 	}
 
@@ -111,7 +115,7 @@ public class GlobalLogConfigurationTests
 		static void Check(string key, string envVarValue)
 		{
 			var config = CreateConfig(key, envVarValue);
-			config.LogDirectory.Should().StartWith("/foo/bar", "{0}", key);
+			Assert.StartsWith("/foo/bar", config.LogDirectory);
 		}
 	}
 
@@ -137,7 +141,7 @@ public class GlobalLogConfigurationTests
 		static void Check(string key, string? envVarValue, LogTargets? targets)
 		{
 			var config = CreateConfig(key, envVarValue);
-			config.LogTargets.Should().Be(targets, "{0}", key);
+			Assert.Equal(targets, config.LogTargets);
 		}
 	}
 
@@ -158,8 +162,9 @@ public class GlobalLogConfigurationTests
 			env.Add(ELASTIC_OTEL_LOG_TARGETS, logTargetsEnvValue);
 
 		var config = new CompositeElasticOpenTelemetryOptions(env);
-		config.GlobalLogEnabled.Should().Be(globalLogging);
-		config.LogTargets.Should().Be(targets);
+
+		Assert.Equal(globalLogging, config.GlobalLogEnabled);
+		Assert.Equal(targets, config.LogTargets);
 	}
 
 	private static CompositeElasticOpenTelemetryOptions CreateConfig(string key, string? envVarValue)

--- a/tests/Elastic.OpenTelemetry.Tests/Elastic.OpenTelemetry.Tests.csproj
+++ b/tests/Elastic.OpenTelemetry.Tests/Elastic.OpenTelemetry.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.11.1" />
   </ItemGroup>
 

--- a/tests/Elastic.OpenTelemetry.Tests/GlobalUsings.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/GlobalUsings.cs
@@ -1,9 +1,9 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
 global using System.Diagnostics;
 global using Elastic.OpenTelemetry.Processors;
-global using FluentAssertions;
 global using OpenTelemetry.Resources;
 global using OpenTelemetry.Trace;
 global using Xunit;

--- a/tests/Elastic.OpenTelemetry.Tests/Processors/ElasticCompatibilityProcessorTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Processors/ElasticCompatibilityProcessorTests.cs
@@ -44,10 +44,10 @@ public sealed class ElasticCompatibilityProcessorTests : IDisposable
 		sut.OnEnd(activity);
 
 		// We can test with Tags (rather than TagObjects) here as we know these are string values
-		activity.Tags.Single(t => t.Key == TraceSemanticConventions.NetHostName).Value.Should().Be(hostName);
+		Assert.Equal(hostName, activity.Tags.Single(t => t.Key == TraceSemanticConventions.NetHostName).Value);
 
-		activity.TagObjects.Single(t => t.Key == TraceSemanticConventions.NetHostPort).Value
-			.Should().BeOfType<int>().Subject.Should().Be(port);
+		var netHostPort = Assert.IsType<int>(activity.TagObjects.Single(t => t.Key == TraceSemanticConventions.NetHostPort).Value);
+		Assert.Equal(port, netHostPort);
 	}
 
 	[Fact]
@@ -65,8 +65,8 @@ public sealed class ElasticCompatibilityProcessorTests : IDisposable
 		sut.OnEnd(activity);
 
 		// We can test with Tags (rather than TagObjects) here as we know these are string values
-		activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpScheme).Value.Should().Be(scheme);
-		activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpTarget).Value.Should().Be(path);
+		Assert.Equal(scheme, activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpScheme).Value);
+		Assert.Equal(path, activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpTarget).Value);
 	}
 
 	[Fact]
@@ -86,8 +86,8 @@ public sealed class ElasticCompatibilityProcessorTests : IDisposable
 		sut.OnEnd(activity);
 
 		// We can test with Tags (rather than TagObjects) here as we know these are string values
-		activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpScheme).Value.Should().Be(scheme);
-		activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpTarget).Value.Should().Be($"{path}{query}");
+		Assert.Equal(scheme, activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpScheme).Value);
+		Assert.Equal($"{path}{query}", activity.Tags.Single(t => t.Key == TraceSemanticConventions.HttpTarget).Value);
 	}
 
 	public void Dispose()


### PR DESCRIPTION
FluentAssertions v8 is moving to a paid model. This PR removes the use of this package so that we don't accidentally end up running a version outside of its license. We now prefer the xunit assertions.