### PR TITLE
Metric enhancements and fix resource attributes

### DIFF
--- a/.github/workflows/bootstrap/action.yml
+++ b/.github/workflows/bootstrap/action.yml
@@ -38,9 +38,12 @@ runs:
       uses: actions/setup-dotnet@v4
       with:
         global-json-file: ./global.json
+        # 6.x is required for the release-notes tool.
         # 7.x is required for the dotnet-project-licenses tool.
         dotnet-version: |
+            6.x
             7.x
+            8.x
 
     - id: dotnet
       shell: bash

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -136,7 +136,7 @@ let private generateApiChanges _ =
                 "assembly-differ"
                 $"previous-nuget|%s{p}|%s{currentVersion}|%s{tfm}";
                 //$"directory|.artifacts/bin/%s{p}/release/%s{tfm}";
-                $"directory|.artifacts/bin/%s{p}/release_net8.0";
+                $"directory|.artifacts/bin/%s{p}/release_net9.0";
                 "-a"; "true"; "--target"; p; "-f"; "github-comment"; "--output"; outputFile
             ]
         exec { run "dotnet" args }

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "assembly-differ": {
-      "version": "0.15.0",
+      "version": "0.16.0",
       "commands": [
         "assembly-differ"
       ]
@@ -21,7 +21,7 @@
       ]
     },
     "nupkg-validator": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "commands": [
         "nupkg-validator"
       ]

--- a/examples/Example.AspNetCore.Mvc/Program.cs
+++ b/examples/Example.AspNetCore.Mvc/Program.cs
@@ -2,15 +2,12 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using OpenTelemetry;
-using OpenTelemetry.Trace;
-
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddElasticOpenTelemetry();
+
 builder.Services
-	.AddHttpClient()
-	.AddElasticOpenTelemetry()
-		.WithTracing(t => t.AddAspNetCoreInstrumentation()); // This is redundant but used in manual testing for now
+	.AddHttpClient();
 
 builder.Services
 	.AddControllersWithViews();

--- a/examples/Example.AspNetCore.Mvc/appsettings.json
+++ b/examples/Example.AspNetCore.Mvc/appsettings.json
@@ -14,7 +14,8 @@
   "Elastic": {
     "OpenTelemetry": {
       "LogLevel": "Trace",
-      "LogDirectory": "C:\\Logs\\BrandNewLogs"
+      "LogDirectory": "C:\\Logs\\BrandNewLogs",
+      "LogTargets": "file;stdout"
     }
   }
 }

--- a/examples/ServiceDefaults/ServiceDefaults.csproj
+++ b/examples/ServiceDefaults/ServiceDefaults.csproj
@@ -14,10 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Elastic.OpenTelemetry.AutoInstrumentation/Elastic.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/Elastic.OpenTelemetry.AutoInstrumentation/Elastic.OpenTelemetry.AutoInstrumentation.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net462</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-      <IsPackable>True</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>True</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.10.0" GeneratePathProperty="true" PrivateAssets="contentfiles" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.10.0" GeneratePathProperty="true" PrivateAssets="contentfiles" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Remove="README.md" />
@@ -23,23 +23,22 @@
 
     <!-- ensure we remove the linked instrument.sh from base OpenTelemetry.AutoInstrumentation
           and link it as _instrument.sh since we manually copy it over in the prebuild event -->
-    
+
     <Content Update="instrument.sh" CopyToPublishDirectory="Never" CopyToOutputDirectory="Never" />
     <Content Remove="instrument.sh" />
     <Content Include="_instrument.sh" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Pack="True" PackagePath="contentFiles/any/any/_instrument.sh" />
     <Content Include="instrument.sh" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Pack="True" PackagePath="contentFiles/any/any/instrument.sh" />
 
     <Content Include="instrument.props" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Pack="True" PackagePath="build/elastic.opentelemetry.autoinstrumentation.props" />
-
   </ItemGroup>
-  
+
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <!-- Copies the content files manually as physical files in the source repository -->
-    <!-- we manually repackage these as contentfiles (albeit renamed) --> 
+    <!-- we manually repackage these as contentfiles (albeit renamed) -->
     <Copy SourceFiles="$(PkgOpenTelemetry_AutoInstrumentation)/contentFiles/any/any/instrument.cmd" DestinationFiles="$(MSBuildThisFileDirectory)/_instrument.cmd" />
     <Copy SourceFiles="$(PkgOpenTelemetry_AutoInstrumentation)/contentFiles/any/any/instrument.sh" DestinationFiles="$(MSBuildThisFileDirectory)/_instrument.sh" />
   </Target>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Elastic.OpenTelemetry\Elastic.OpenTelemetry.csproj" />
   </ItemGroup>

--- a/src/Elastic.OpenTelemetry/Core/AutoInstrumentationPlugin.cs
+++ b/src/Elastic.OpenTelemetry/Core/AutoInstrumentationPlugin.cs
@@ -104,5 +104,5 @@ public class AutoInstrumentationPlugin
 	public ResourceBuilder ConfigureResource(ResourceBuilder builder) =>
 		!_bootstrapInfo.Succeeded || _components is null
 			? builder
-			: builder.AddElasticDistroAttributes();
+			: builder.WithElasticDefaults();
 }

--- a/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
+++ b/src/Elastic.OpenTelemetry/Diagnostics/LoggerMessages.cs
@@ -38,55 +38,67 @@ internal static partial class LoggerMessages
 	[LoggerMessage(EventId = 8, EventName = "LocatedInstrumentationAssembly", Level = LogLevel.Trace, Message = "Located {AssemblyFilename} in {Path}.")]
 	public static partial void LogLocatedInstrumentationAssembly(this ILogger logger, string assemblyFilename, string path);
 
-	[LoggerMessage(EventId = 9, EventName = "AddedInstrumentation", Level = LogLevel.Debug, Message = "Added {InstrumentationName} to {ProviderBuilderType}.")]
-	public static partial void LogAddedInstrumentation(this ILogger logger, string instrumentationName, string providerBuilderType);
-
-	[LoggerMessage(EventId = 10, EventName = "AddedInstrumentationViaReflection", Level = LogLevel.Debug, Message = "Added {InstrumentationName} to {ProviderBuilderType} via reflection assembly scanning.")]
-	public static partial void LogAddedInstrumentationViaReflection(this ILogger logger, string instrumentationName, string providerBuilderType);
-
-	[LoggerMessage(EventId = 11, EventName = "HttpInstrumentationFound", Level = LogLevel.Debug, Message = "The contrib HTTP instrumentation library was located alongside the executing assembly. " +
-		"Skipping adding native {InstrumentationType} instrumentation from the 'System.Net.Http' ActivitySource.")]
-	public static partial void LogHttpInstrumentationFound(this ILogger logger, string instrumentationType);
-
-	[LoggerMessage(EventId = 12, EventName = "RuntimeInstrumentationFound", Level = LogLevel.Debug, Message = "The contrib runtime instrumentation library was located alongside the executing assembly. " +
-		"Skipping adding native metric instrumentation from the 'System.Runtime' ActivitySource.")]
-	public static partial void LogRuntimeInstrumentationFound(this ILogger logger);
-
-	[LoggerMessage(EventId = 13, EventName = "SignalDisabled", Level = LogLevel.Information, Message = "Skipping configuring and setting EDOT defaults for {Signal}, as these have been disabled via configuration.")]
-	public static partial void LogSignalDisabled(this ILogger logger, string signal);
-
-	[LoggerMessage(EventId = 14, EventName = "ProviderBuilderSignalDisabled", Level = LogLevel.Information, Message = "Skipping configuring and setting EDOT defaults for {Signal} on {ProviderBuilderType}, " +
-		"as these have been disabled via configuration.")]
-	public static partial void LogSignalDisabled(this ILogger logger, string signal, string providerBuilderType);
-
-	[LoggerMessage(EventId = 15, EventName = "SkippingBootstrap", Level = LogLevel.Warning, Message = "Skipping EDOT bootstrap and provider configuration because the `Signals` configuration is set to `None`. " +
-		"This likely represents a misconfiguration. If you do not want to use the EDOT for any signals, avoid calling `WithElasticDefaults` on the builder.")]
-	public static partial void LogSkippingBootstrapWarning(this ILogger logger);
-
 	// We explictly reuse the same event ID and this is the same log message, but with different types for the structured data
-	[LoggerMessage(EventId = 9, Level = LogLevel.Debug, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	[LoggerMessage(EventId = 9, Level = LogLevel.Trace, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void FoundTag(this ILogger logger, string processorName, string attributeName, string attributeValue);
 
 	// We explictly reuse the same event ID and this is the same log message, but with different types for the structured data
-	[LoggerMessage(EventId = 9, Level = LogLevel.Debug, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	[LoggerMessage(EventId = 9, Level = LogLevel.Trace, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void FoundTag(this ILogger logger, string processorName, string attributeName, int attributeValue);
 
 	// We explictly reuse the same event ID and this is the same log message, but with different types for the structured data
-	[LoggerMessage(EventId = 10, Level = LogLevel.Debug, Message = "{ProcessorName} set `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	[LoggerMessage(EventId = 10, Level = LogLevel.Trace, Message = "{ProcessorName} set `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void SetTag(this ILogger logger, string processorName, string attributeName, string attributeValue);
 
 	// We explictly reuse the same event ID and this is the same log message, but with different types for the structured data
-	[LoggerMessage(EventId = 10, Level = LogLevel.Debug, Message = "{ProcessorName} set `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	[LoggerMessage(EventId = 10, Level = LogLevel.Trace, Message = "{ProcessorName} set `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void SetTag(this ILogger logger, string processorName, string attributeName, int attributeValue);
 
-	[LoggerMessage(EventId = 11, Level = LogLevel.Debug, Message = "Added '{ProcessorTypeName}' processor to '{BuilderTypeName}'.")]
-	public static partial void LogProcessorAdded(this ILogger logger, string processorTypeName, string builderTypeName);
+	[LoggerMessage(EventId = 11, Level = LogLevel.Debug, Message = "Added '{ProcessorTypeName}' processor to {BuilderTypeName} with ID '{BuilderIdentifier}'.")]
+	public static partial void LogProcessorAdded(this ILogger logger, string processorTypeName, string builderTypeName, string builderIdentifier);
 
-	[LoggerMessage(EventId = 12, Level = LogLevel.Debug, Message = "Added '{MeterName}' meter to '{BuilderTypeName}'.")]
+	[LoggerMessage(EventId = 12, Level = LogLevel.Debug, Message = "Added '{MeterName}' meter to {BuilderTypeName}.")]
 	public static partial void LogMeterAdded(this ILogger logger, string meterName, string builderTypeName);
 
 	[LoggerMessage(EventId = 13, Level = LogLevel.Error, Message = "Unable to configure {BuilderTypeName} with EDOT .NET logging defaults.")]
 	public static partial void UnableToConfigureLoggingDefaultsError(this ILogger logger, string builderTypeName);
+
+	[LoggerMessage(EventId = 14, EventName = "AddedInstrumentation", Level = LogLevel.Debug, Message = "Added {InstrumentationName} to {ProviderBuilderType}.")]
+	public static partial void LogAddedInstrumentation(this ILogger logger, string instrumentationName, string providerBuilderType);
+
+	[LoggerMessage(EventId = 15, EventName = "AddedInstrumentationViaReflection", Level = LogLevel.Debug, Message = "Added {InstrumentationName} to {ProviderBuilderType} via reflection assembly scanning.")]
+	public static partial void LogAddedInstrumentationViaReflection(this ILogger logger, string instrumentationName, string providerBuilderType);
+
+	[LoggerMessage(EventId = 16, EventName = "HttpInstrumentationFound", Level = LogLevel.Debug, Message = "The contrib HTTP instrumentation library was located alongside the executing assembly. " +
+		"Skipping adding native {InstrumentationType} instrumentation from the 'System.Net.Http' ActivitySource to '{ProviderBuilderType}' with ID '{BuilderIdentifier}'.")]
+	public static partial void LogHttpInstrumentationFound(this ILogger logger, string instrumentationType, string providerBuilderType, string builderIdentifier);
+
+	[LoggerMessage(EventId = 17, EventName = "RuntimeInstrumentationFound", Level = LogLevel.Debug, Message = "The contrib runtime instrumentation library was located alongside the executing assembly. " +
+		"Skipping adding native metric instrumentation from the 'System.Runtime' ActivitySource.")]
+	public static partial void LogRuntimeInstrumentationFound(this ILogger logger);
+
+	[LoggerMessage(EventId = 18, EventName = "SignalDisabled", Level = LogLevel.Information, Message = "Skipping configuring and setting EDOT defaults for {Signal}, as these have been disabled via configuration.")]
+	public static partial void LogSignalDisabled(this ILogger logger, string signal);
+
+	[LoggerMessage(EventId = 19, EventName = "ProviderBuilderSignalDisabled", Level = LogLevel.Information, Message = "Skipping configuring and setting EDOT defaults for {Signal} on {ProviderBuilderType}, " +
+		"as these have been disabled via configuration.")]
+	public static partial void LogSignalDisabled(this ILogger logger, string signal, string providerBuilderType);
+
+	[LoggerMessage(EventId = 20, EventName = "SkippingBootstrap", Level = LogLevel.Warning, Message = "Skipping EDOT bootstrap and provider configuration because the `Signals` configuration is set to `None`. " +
+		"This likely represents a misconfiguration. If you do not want to use the EDOT for any signals, avoid calling `WithElasticDefaults` on the builder.")]
+	public static partial void LogSkippingBootstrapWarning(this ILogger logger);
+
+	[LoggerMessage(EventId = 21, EventName = "LogAddedMeter", Level = LogLevel.Warning, Message = "Added {MeterName} to resource builder '{BuilderIdentifier}'.")]
+	public static partial void LogAddedMeter(this ILogger logger, string meterName, string builderIdentifier);
+
+	[LoggerMessage(EventId = 22, EventName = "ResourceBuilderAlreadyConfigured", Level = LogLevel.Debug, Message = "The resource builder '{BuilderIdentifier}' has already been configured with EDOT defaults.")]
+	public static partial void LogResourceBuilderAlreadyConfigured(this ILogger logger, string builderIdentifier);
+
+	[LoggerMessage(EventId = 23, EventName = "ResourceBuilderConfigured", Level = LogLevel.Debug, Message = "Configuring the resource builder '{BuilderIdentifier}' with EDOT defaults.")]
+	public static partial void LogResourceBuilderConfigured(this ILogger logger, string builderIdentifier);
+
+	[LoggerMessage(EventId = 24, EventName = "ConfiguringBuilder", Level = LogLevel.Information, Message = "Configuring the {ProviderBuilderType} with ID '{BuilderIdentifier}' with EDOT defaults.")]
+	public static partial void LogConfiguringBuilder(this ILogger logger, string providerBuilderType, string builderIdentifier);
 
 	public static void LogDistroPreamble(this ILogger logger, SdkActivationMethod activationMethod, ElasticOpenTelemetryComponents components)
 	{

--- a/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
+++ b/src/Elastic.OpenTelemetry/Elastic.OpenTelemetry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -33,7 +33,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.11.0-beta.1" />
-    <PackageReference Include="Polyfill" Version="7.16.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Polyfill" Version="7.20.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta09" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 
@@ -42,8 +42,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <!-- We skip this on .NET since we prefer to use the native instrumentation from the builtin Meter -->
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <!-- We skip this on .NET since we prefer to use the native instrumentation from the builtin ActivitySource -->
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
   </ItemGroup>
   

--- a/src/Elastic.OpenTelemetry/Extensions/LoggingProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/LoggingProviderBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.Resources;
 
 // Matching namespace with LoggerProviderBuilder
 #pragma warning disable IDE0130 // Namespace does not match folder structure
@@ -18,7 +19,7 @@ namespace OpenTelemetry.Logs;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 /// <summary>
-/// Extension methods for <see cref="LoggerProviderBuilder"/> used to register
+/// Provides extension methods on the <see cref="LoggerProviderBuilder"/> used to register
 /// the Elastic Distribution of OpenTelemetry (EDOT) defaults.
 /// </summary>
 public static class LoggingProviderBuilderExtensions
@@ -127,7 +128,7 @@ public static class LoggingProviderBuilderExtensions
 
 		static void ConfigureBuilder(LoggerProviderBuilder builder, ElasticOpenTelemetryComponents components)
 		{
-			builder.ConfigureResource(r => r.AddElasticDistroAttributes());
+			builder.ConfigureResource(r => r.WithElasticDefaults(components.Logger));
 
 			if (components.Options.SkipOtlpExporter)
 			{

--- a/src/Elastic.OpenTelemetry/Extensions/OpenTelemetryBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/OpenTelemetryBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 /// <summary>
-/// Extension methods on <see cref="IOpenTelemetryBuilder"/> and <see cref="OpenTelemetryBuilder"/>
+/// Provides extension methods on the <see cref="IOpenTelemetryBuilder"/>
 /// used to register the Elastic Distribution of OpenTelemetry (EDOT) defaults.
 /// </summary>
 public static class OpenTelemetryBuilderExtensions

--- a/src/Elastic.OpenTelemetry/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/ResourceBuilderExtensions.cs
@@ -3,52 +3,60 @@
 // See the LICENSE file in the project root for more information
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Elastic.OpenTelemetry.Core;
+using Elastic.OpenTelemetry.Diagnostics;
+using Elastic.OpenTelemetry.Instrumentation;
 using Elastic.OpenTelemetry.SemanticConventions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using OpenTelemetry.Resources;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
-namespace OpenTelemetry;
+namespace OpenTelemetry.Resources;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 /// <summary>
-/// Extension methods for <see cref="ResourceBuilder"/>.
+/// Provides extension methods on the <see cref="ResourceBuilder"/> used to register
+/// the Elastic Distribution of OpenTelemetry (EDOT) defaults.
 /// </summary>
-public static class ResourceBuilderExtensions
+internal static class ResourceBuilderExtensions
 {
 	private static readonly string InstanceId = Guid.NewGuid().ToString();
 
-	/// <summary>
-	/// For advanced scenarios, where the all Elastic defaults are not disabled (essentially using the "vanilla" OpenTelemetry SDK),
-	/// this method can be used to add Elastic resource defaults to the <see cref="ResourceBuilder"/>.
-	/// </summary>
-	/// <remarks>
-	/// After clearing the <see cref="ResourceBuilder"/> the following are added in order:
-	/// <list type="bullet">
-	/// <item>A default, fallback <c>service.name</c>.</item>
-	/// <item>A default, unqiue <c>service.instance.id</c>.</item>
-	/// <item>The telemetry SDK attributes via <c>AddTelemetrySdk()</c>.</item>
-	/// <item>The Elastic telemetry distro attributes.</item>
-	/// <item>Adds resource attributes parsed from OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME environment variables
-	/// via <c>AddEnvironmentVariableDetector()</c>.</item>
-	/// <item>Host attributes, <c>host.name</c> and <c>host.id</c> (on supported targets).</item>
-	/// </list>
-	/// <para>These mostly mirror what the vanilla SDK does, but allow us to ensure that certain resources attributes that the
-	/// Elastic APM backend requires to drive the UIs are present in some form. Any of these may be overridden by further
-	/// resource configuration.</para>
-	/// </remarks>
-	/// <param name="builder">A <see cref="ResourceBuilder"/> that will be configured with Elastic defaults.</param>
-	/// <param name="logger">Optionally provide a logger to log to</param>
-	/// <returns>The <see cref="ResourceBuilder"/> for chaining calls.</returns>
-	public static ResourceBuilder WithElasticDefaults(this ResourceBuilder builder, ILogger? logger = null)
+#pragma warning disable IDE0028 // Simplify collection initialization
+	private static readonly ConditionalWeakTable<ResourceBuilder, string> ConfiguredBuilders = new();
+#pragma warning restore IDE0028 // Simplify collection initialization
+
+#if !NET
+	private static readonly Lock Lock = new();
+#endif
+
+	public static ResourceBuilder WithElasticDefaults(this ResourceBuilder builder) =>
+		WithElasticDefaults(builder, NullLogger.Instance);
+
+	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "The call to `AssemblyScanning.AddInstrumentationViaReflection` " +
+		"is guarded by a RuntimeFeature.IsDynamicCodeSupported` check and therefore this method is safe to call in AoT scenarios.")]
+	public static ResourceBuilder WithElasticDefaults(this ResourceBuilder builder, ILogger logger)
 	{
-		// ReSharper disable once RedundantAssignment
-#pragma warning disable IDE0059 // Unnecessary assignment of a value
-		logger ??= NullLogger.Instance;
-#pragma warning restore IDE0059 // Unnecessary assignment of a value
 		var defaultServiceName = "unknown_service";
+
+		if (ConfiguredBuilders.TryGetValue(builder, out var builderIdentifier))
+		{
+			logger.LogResourceBuilderAlreadyConfigured($"{builderIdentifier}:{builder.GetHashCode()}");
+			return builder;
+		}
+
+		builderIdentifier = Guid.NewGuid().ToString();
+
+#if NET
+		ConfiguredBuilders.TryAdd(builder, builderIdentifier);
+#else
+		using (var scope = Lock.EnterScope())
+		{
+			ConfiguredBuilders.Add(builder, builderIdentifier);
+		}
+#endif
 
 		try
 		{
@@ -62,24 +70,26 @@ public static class ResourceBuilderExtensions
 		}
 
 		builder
-			.Clear()
 			.AddAttributes(new Dictionary<string, object>
 			{
 				{ ResourceSemanticConventions.AttributeServiceName, defaultServiceName },
-				{ ResourceSemanticConventions.AttributeServiceInstanceId, InstanceId }
-			})
-			.AddTelemetrySdk()
-			.AddElasticDistroAttributes()
-			.AddEnvironmentVariableDetector()
-			.AddHostDetector();
+				{ ResourceSemanticConventions.AttributeServiceInstanceId, InstanceId },
+				{ ResourceSemanticConventions.AttributeTelemetryDistroName, "elastic" },
+				{ ResourceSemanticConventions.AttributeTelemetryDistroVersion, VersionHelper.InformationalVersion }
+			});
+
+#if NET
+		if (RuntimeFeature.IsDynamicCodeSupported)
+#endif
+		{
+			// Currently, this adds just the HostDetector is the DLL is present. This ensures that this method can be called
+			// by auto-instrumentation which won't ship with that DLL. For the NuGet package, we depend on it so it will always
+			// be present.
+			SignalBuilder.AddInstrumentationViaReflection(builder, logger, ContribResourceDetectors.GetContribResourceDetectors());
+		}
+
+		logger.LogResourceBuilderConfigured($"{builderIdentifier}:{builder.GetHashCode()}");
 
 		return builder;
 	}
-
-	internal static ResourceBuilder AddElasticDistroAttributes(this ResourceBuilder builder) =>
-		builder.AddAttributes(new Dictionary<string, object>
-		{
-			{ ResourceSemanticConventions.AttributeTelemetryDistroName, "elastic" },
-			{ ResourceSemanticConventions.AttributeTelemetryDistroVersion, VersionHelper.InformationalVersion }
-		});
 }

--- a/src/Elastic.OpenTelemetry/Instrumentation/ContribMetricsInstrumentation.cs
+++ b/src/Elastic.OpenTelemetry/Instrumentation/ContribMetricsInstrumentation.cs
@@ -83,13 +83,5 @@ internal static class ContribMetricsInstrumentation
 			InstrumentationMethod = "AddHttpClientInstrumentation"
 		},
 #endif
-
-		new()
-		{
-			Name = "Process",
-			Filename = "OpenTelemetry.Instrumentation.Process.dll",
-			FullyQualifiedType = "OpenTelemetry.Metrics.MeterProviderBuilderExtensions",
-			InstrumentationMethod = "AddProcessInstrumentation"
-		},
 	];
 }

--- a/src/Elastic.OpenTelemetry/Instrumentation/ContribResourceDetectors.cs
+++ b/src/Elastic.OpenTelemetry/Instrumentation/ContribResourceDetectors.cs
@@ -1,0 +1,24 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.OpenTelemetry.Instrumentation;
+
+internal static class ContribResourceDetectors
+{
+	// Note: This is defined as a static method and allocates the array each time.
+	// This is intentional, as we expect this to be invoked once (or worst case, few times).
+	// After initialisation, the array is no longer required and can be reclaimed by the GC.
+	// This is likley to be overall more efficient for the common scenario as we don't keep
+	// an object alive for the lifetime of the application.
+	public static InstrumentationAssemblyInfo[] GetContribResourceDetectors() =>
+	[
+		new()
+		{
+			Name = "HostDetector",
+			Filename = "OpenTelemetry.Resources.Host.dll",
+			FullyQualifiedType = "OpenTelemetry.Resources.HostResourceBuilderExtensions",
+			InstrumentationMethod = "AddHostDetector"
+		}
+	];
+}

--- a/tests/Elastic.OpenTelemetry.Tests/InstrumentationScanningTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/InstrumentationScanningTests.cs
@@ -33,7 +33,7 @@ public partial class InstrumentationScanningTests(WebApplicationFactory<Program>
 	[GeneratedRegex(@"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\]\[\d{5}\]\[-*\]\[Debug\]\s+Added HTTP \(via native instrumentation\) to TracerProviderBuilder.*")]
 	private static partial Regex HttpTracerProviderBuilderRegex();
 
-	[GeneratedRegex(@"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\]\[\d{5}\]\[-*\]\[Debug\]\s+Added HTTP \(via native instrumentation\) to MeterProviderBuilder.*")]
+	[GeneratedRegex(@"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\]\[\d{5}\]\[-*\]\[Debug\]\s+Added 'System.Net.Http' meter to MeterProviderBuilder.*")]
 	private static partial Regex HttpMeterProviderBuilderRegex();
 #endif
 


### PR DESCRIPTION
This subscribes to additional metrics out of the box and reactors that code a little.

After an earlier refactoring, we were not setting the required resource attributes, which would cause breaks in the curated dashboard. This has been fixed.