### PR TITLE
allow wget in elastic-dotnet-auto-install.sh

### DIFF
--- a/build/patch-dotnet-auto-install.sh
+++ b/build/patch-dotnet-auto-install.sh
@@ -46,6 +46,15 @@ case "$ARCHITECTURE" in
     ;;
 esac
 
+if command -v curl > /dev/null 2>&1; then
+  DOWNLOADER="curl -sSfLo"
+elif command -v wget > /dev/null 2>&1; then
+  DOWNLOADER="wget -qO"
+else
+  echo "Error: Neither curl nor wget is available." >&2
+  exit 1
+fi
+
 test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
 test -z "$VERSION" && VERSION="v1.9.0"
 
@@ -64,7 +73,7 @@ if [ ! -f "${LOCAL_PATH}" ]; then
   (
     cd "$DOWNLOAD_DIR"
     echo "Downloading $VERSION for $OS_TYPE ($LOCAL_PATH)..."
-    curl -sSfLo "$LOCAL_PATH" "$RELEASES_URL/download/$VERSION/$ARCHIVE"
+    ${DOWNLOADER} "$LOCAL_PATH" "$RELEASES_URL/download/$VERSION/$ARCHIVE"
   )
 else
   echo "Using local installation archive: $LOCAL_PATH"


### PR DESCRIPTION
This is the same fix as upstream here, which allows use of wget when curl isn't available, helpful on the runtime docker images. https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/4076

I tested it with a copy like below

wget and not curl 
```bash
$ docker run --rm -it mcr.microsoft.com/dotnet/runtime:8.0-alpine
/ # sh -xc "$(wget -qO- https://gist.githubusercontent.com/codefromthecrypt/77865a27ad40dc4fa7ef35396a0ba4dc/raw/fa516690ee5afad5d53f1c4e7671a47a207b24d1/elastic-dotnet-auto-
install.sh)"
+ set -e
+ '[' -z  ]
+ uname -s
+ tr '[:upper:]' '[:lower:]'
+ ldd /bin/ls
+ grep -m1 musl
+ '[' ' /lib/ld-musl-aarch64.so.1 (0xfe39c41a3000)' ]
+ OS_TYPE=linux-musl
+ '[' -z  ]
+ uname -m
+ ARCHITECTURE=arm64
+ command -v curl
+ command -v wget
+ DOWNLOADER='wget -qO'
+ test -z 
+ OTEL_DOTNET_AUTO_HOME=/root/.otel-dotnet-auto
+ test -z 
+ VERSION=1.0.0-alpha.6
+ mktemp -d
+ DOWNLOAD_DIR=/tmp/tmp.EPCdHh
+ RELEASES_URL=https://github.com/elastic/elastic-otel-dotnet/releases
+ ARCHIVE=elastic-dotnet-instrumentation-linux-musl.zip
+ echo linux-musl
+ grep -q linux
+ ARCHIVE=elastic-dotnet-instrumentation-linux-musl-arm64.zip
+ LOCAL_PATH=/tmp/tmp.EPCdHh/elastic-dotnet-instrumentation-linux-musl-arm64.zip
+ '[' '!' -f /tmp/tmp.EPCdHh/elastic-dotnet-instrumentation-linux-musl-arm64.zip ]
+ cd /tmp/tmp.EPCdHh
+ echo 'Downloading 1.0.0-alpha.6 for linux-musl (/tmp/tmp.EPCdHh/elastic-dotnet-instrumentation-linux-musl-arm64.zip)...'
Downloading 1.0.0-alpha.6 for linux-musl (/tmp/tmp.EPCdHh/elastic-dotnet-instrumentation-linux-musl-arm64.zip)...
+ wget -qO /tmp/tmp.EPCdHh/elastic-dotnet-instrumentation-linux-musl-arm64.zip https://github.com/elastic/elastic-otel-dotnet/releases/download/1.0.0-alpha.6/elastic-dotnet-instrumentation-linux-musl-arm64.zip
+ rm -rf /root/.otel-dotnet-auto
+ unzip -q /tmp/tmp.EPCdHh/elastic-dotnet-instrumentation-linux-musl-arm64.zip -d /root/.otel-dotnet-auto

```

Curl still works

```
± |main {2} U:1 ✗| → docker run --rm -it mcr.microsoft.com/dotnet/sdk:8.0-alpine
Unable to find image 'mcr.microsoft.com/dotnet/sdk:8.0-alpine' locally
8.0-alpine: Pulling from dotnet/sdk
6e771e15690e: Already exists 
22672aa052ce: Already exists 
f933357a8a45: Already exists 
0cf14cd91458: Already exists 
f48aab829812: Already exists 
9a429f248167: Already exists 
7af66d400433: Already exists 
Digest: sha256:1659a7a350b7847f6afc84df1409c6b80fd08e7decf51f5c365303b0d625f13b
Status: Downloaded newer image for mcr.microsoft.com/dotnet/sdk:8.0-alpine
/ # sh -xc "$(curl -fsSL https://gist.githubusercontent.com/codefromthecrypt/77865a27ad40dc4fa7ef35396a0ba4dc/raw/fa516690ee5afad5d53f1c4e7671a47a207b24d1/elastic-dotnet-auto
-install.sh)"
+ set -e
+ '[' -z  ]
+ uname -s
+ tr '[:upper:]' '[:lower:]'
+ ldd /bin/ls
+ grep -m1 musl
+ '[' ' /lib/ld-musl-aarch64.so.1 (0xe9a87ee35000)' ]
+ OS_TYPE=linux-musl
+ '[' -z  ]
+ uname -m
+ ARCHITECTURE=arm64
+ command -v curl
+ DOWNLOADER='curl -sSfLo'
+ test -z 
+ OTEL_DOTNET_AUTO_HOME=/root/.otel-dotnet-auto
+ test -z 
+ VERSION=1.0.0-alpha.6
+ mktemp -d
+ DOWNLOAD_DIR=/tmp/tmp.mECpGE
+ RELEASES_URL=https://github.com/elastic/elastic-otel-dotnet/releases
+ ARCHIVE=elastic-dotnet-instrumentation-linux-musl.zip
+ echo linux-musl
+ grep -q linux
+ ARCHIVE=elastic-dotnet-instrumentation-linux-musl-arm64.zip
+ LOCAL_PATH=/tmp/tmp.mECpGE/elastic-dotnet-instrumentation-linux-musl-arm64.zip
+ '[' '!' -f /tmp/tmp.mECpGE/elastic-dotnet-instrumentation-linux-musl-arm64.zip ]
+ cd /tmp/tmp.mECpGE
+ echo 'Downloading 1.0.0-alpha.6 for linux-musl (/tmp/tmp.mECpGE/elastic-dotnet-instrumentation-linux-musl-arm64.zip)...'
Downloading 1.0.0-alpha.6 for linux-musl (/tmp/tmp.mECpGE/elastic-dotnet-instrumentation-linux-musl-arm64.zip)...
+ curl -sSfLo /tmp/tmp.mECpGE/elastic-dotnet-instrumentation-linux-musl-arm64.zip https://github.com/elastic/elastic-otel-dotnet/releases/download/1.0.0-alpha.6/elastic-dotnet-instrumentation-linux-musl-arm64.zip
+ rm -rf /root/.otel-dotnet-auto
+ unzip -q /tmp/tmp.mECpGE/elastic-dotnet-instrumentation-linux-musl-arm64.zip -d /root/.otel-dotnet-auto

```