### PR TITLE
Remove compatibility processor registration

### DIFF
--- a/src/Elastic.OpenTelemetry.Core/Extensions/TracerProvderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry.Core/Extensions/TracerProvderBuilderExtensions.cs
@@ -8,7 +8,6 @@ using Elastic.OpenTelemetry;
 using Elastic.OpenTelemetry.Configuration;
 using Elastic.OpenTelemetry.Core;
 using Elastic.OpenTelemetry.Diagnostics;
-using Elastic.OpenTelemetry.Processors;
 using Elastic.OpenTelemetry.Resources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -95,7 +94,6 @@ public static class CoreTracerProvderBuilderExtensions
 		{
 			// When we have existing builderState, this method is being invoked from the main WithElasticDefaults method.
 			// In that scenario, we skip configuring the resource, as it will have already been configured by the caller.
-			ConfigureBuilderProcessors(builder, builderState, services);
 			return builder;
 		}
 
@@ -105,13 +103,6 @@ public static class CoreTracerProvderBuilderExtensions
 		static void ConfigureBuilder(TracerProviderBuilder builder, BuilderState builderState, IServiceCollection? services)
 		{
 			builder.ConfigureResource(r => r.WithElasticDefaultsCore(builderState, services, null));
-			builder.LogAndAddProcessor(new ElasticCompatibilityProcessor(builderState.Components.Logger), builderState);
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		static void ConfigureBuilderProcessors(TracerProviderBuilder builder, BuilderState builderState, IServiceCollection? services)
-		{
-			builder.LogAndAddProcessor(new ElasticCompatibilityProcessor(builderState.Components.Logger), builderState);
 		}
 	}
 

--- a/src/Elastic.OpenTelemetry.Core/Processors/ElasticCompatibilityProcessor.cs
+++ b/src/Elastic.OpenTelemetry.Core/Processors/ElasticCompatibilityProcessor.cs
@@ -22,7 +22,7 @@ namespace Elastic.OpenTelemetry.Processors;
 /// </para>
 /// </summary>
 /// <param name="logger"></param>
-public sealed class ElasticCompatibilityProcessor(ILogger? logger) : BaseProcessor<Activity>
+internal sealed class ElasticCompatibilityProcessor(ILogger? logger) : BaseProcessor<Activity>
 {
 	private readonly ILogger _logger = logger ?? NullLogger.Instance;
 


### PR DESCRIPTION
On recent versions of APM server, this is no longer required.

Leaving the processor and methods in place (although unused) in case we need to reintroduce it in the future.

Closes #206