### PR TITLE
Refine public extension methods

### DIFF
--- a/examples/Example.Console/Usage.cs
+++ b/examples/Example.Console/Usage.cs
@@ -49,9 +49,9 @@ internal static class Usage
 		//	.Build();
 
 		using var sdk = OpenTelemetrySdk.Create(builder => builder
-			.WithElasticMetrics()
-			.WithElasticMetrics()
-			.ConfigureResource(resource => resource.AddService("MyCustomServiceName")));
+			.WithElasticDefaults()
+			.ConfigureResource(resource => resource
+				.AddService("MyCustomServiceName")));
 
 		//This is the most flexible approach for a consumer as they can include our processor(s)
 		//using var tracerProvider = Sdk.CreateTracerProviderBuilder()

--- a/src/Elastic.OpenTelemetry.Core/Configuration/CompositeElasticOpenTelemetryOptions.cs
+++ b/src/Elastic.OpenTelemetry.Core/Configuration/CompositeElasticOpenTelemetryOptions.cs
@@ -95,6 +95,37 @@ internal sealed class CompositeElasticOpenTelemetryOptions
 		parser.ParseSkipInstrumentationAssemblyScanning(_skipInstrumentationAssemblyScanning);
 	}
 
+	[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2026:RequiresUnreferencedCode", Justification = "Manually verified")]
+	[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL3050:RequiresDynamicCode", Justification = "Manually verified")]
+	internal CompositeElasticOpenTelemetryOptions(IConfiguration configuration, ElasticOpenTelemetryOptions options)
+		: this((IDictionary?)null)
+	{
+		var parser = new ConfigurationParser(configuration);
+
+		parser.ParseLogDirectory(_logDirectory);
+		parser.ParseLogTargets(_logTargets);
+		parser.ParseLogLevel(_logLevel, ref _eventLevel);
+		parser.ParseSkipOtlpExporter(_skipOtlpExporter);
+		parser.ParseSkipInstrumentationAssemblyScanning(_skipInstrumentationAssemblyScanning);
+
+		if (options.SkipOtlpExporter.HasValue)
+			_skipOtlpExporter.Assign(options.SkipOtlpExporter.Value, ConfigSource.Options);
+
+		if (!string.IsNullOrEmpty(options.LogDirectory))
+			_logDirectory.Assign(options.LogDirectory, ConfigSource.Options);
+
+		if (options.LogLevel.HasValue)
+			_logLevel.Assign(options.LogLevel.Value, ConfigSource.Options);
+
+		if (options.LogTargets.HasValue)
+			_logTargets.Assign(options.LogTargets.Value, ConfigSource.Options);
+
+		if (options.SkipInstrumentationAssemblyScanning.HasValue)
+			_skipInstrumentationAssemblyScanning.Assign(options.SkipInstrumentationAssemblyScanning.Value, ConfigSource.Options);
+
+		AdditionalLogger = options.AdditionalLogger ?? options.AdditionalLoggerFactory?.CreateElasticLogger();
+	}
+
 	internal CompositeElasticOpenTelemetryOptions(ElasticOpenTelemetryOptions options)
 		: this((IDictionary?)null)
 	{
@@ -115,6 +146,9 @@ internal sealed class CompositeElasticOpenTelemetryOptions
 
 		if (options.LogTargets.HasValue)
 			_logTargets.Assign(options.LogTargets.Value, ConfigSource.Options);
+
+		if (options.SkipInstrumentationAssemblyScanning.HasValue)
+			_skipInstrumentationAssemblyScanning.Assign(options.SkipInstrumentationAssemblyScanning.Value, ConfigSource.Options);
 
 		AdditionalLogger = options.AdditionalLogger ?? options.AdditionalLoggerFactory?.CreateElasticLogger();
 	}

--- a/src/Elastic.OpenTelemetry/Extensions/LoggingProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/LoggingProviderBuilderExtensions.cs
@@ -54,25 +54,6 @@ public static class LoggingProviderBuilderExtensions
 	/// <inheritdoc cref="WithElasticDefaults(LoggerProviderBuilder)" />
 	/// </summary>
 	/// <param name="builder"><inheritdoc cref="WithElasticDefaults(LoggerProviderBuilder)" path="/param[@name='builder']"/></param>
-	/// <param name="skipOtlpExporter">When registering Elastic defaults, skip automatic registration of the OTLP exporter for logging.</param>
-	/// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is null.</exception>
-	/// <returns><inheritdoc cref="WithElasticDefaults(LoggerProviderBuilder)" /></returns>
-	public static LoggerProviderBuilder WithElasticDefaults(this LoggerProviderBuilder builder, bool skipOtlpExporter)
-	{
-#if NET
-        ArgumentNullException.ThrowIfNull(builder);
-#else
-		if (builder is null)
-			throw new ArgumentNullException(nameof(builder));
-#endif
-
-		return WithElasticDefaultsCore(builder, skipOtlpExporter ? CompositeElasticOpenTelemetryOptions.SkipOtlpOptions : CompositeElasticOpenTelemetryOptions.DefaultOptions, null, null);
-	}
-
-	/// <summary>
-	/// <inheritdoc cref="WithElasticDefaults(LoggerProviderBuilder)" />
-	/// </summary>
-	/// <param name="builder"><inheritdoc cref="WithElasticDefaults(LoggerProviderBuilder)" path="/param[@name='builder']"/></param>
 	/// <param name="options"><see cref="ElasticOpenTelemetryOptions"/> used to configure the Elastic Distribution of OpenTelemetry (EDOT) .NET.</param>
 	/// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is null.</exception>
 	/// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is null.</exception>

--- a/src/Elastic.OpenTelemetry/Extensions/MeterProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/MeterProviderBuilderExtensions.cs
@@ -61,26 +61,6 @@ public static class MeterProviderBuilderExtensions
 	/// <summary>
 	/// <inheritdoc cref="WithElasticDefaults(MeterProviderBuilder)" />
 	/// </summary>
-	/// <remarks><inheritdoc cref="WithElasticDefaults(MeterProviderBuilder)" /></remarks>
-	/// <param name="builder"><inheritdoc cref="WithElasticDefaults(MeterProviderBuilder)" path="/param[@name='builder']"/></param>
-	/// <param name="skipOtlpExporter">When registering Elastic defaults, skip automatic registration of the OTLP exporter for metrics.</param>
-	/// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is null.</exception>
-	/// <returns><inheritdoc cref="WithElasticDefaults(MeterProviderBuilder)" /></returns>
-	public static MeterProviderBuilder WithElasticDefaults(this MeterProviderBuilder builder, bool skipOtlpExporter)
-	{
-#if NET
-		ArgumentNullException.ThrowIfNull(builder);
-#else
-		if (builder is null)
-			throw new ArgumentNullException(nameof(builder));
-#endif
-
-		return WithElasticDefaultsCore(builder, skipOtlpExporter ? CompositeElasticOpenTelemetryOptions.SkipOtlpOptions : null, null, null);
-	}
-
-	/// <summary>
-	/// <inheritdoc cref="WithElasticDefaults(MeterProviderBuilder)" />
-	/// </summary>
 	/// <param name="builder"><inheritdoc cref="WithElasticDefaults(MeterProviderBuilder)" path="/param[@name='builder']"/></param>
 	/// <param name="options"><see cref="ElasticOpenTelemetryOptions"/> used to configure the Elastic Distribution of OpenTelemetry (EDOT) .NET.</param>
 	/// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is null.</exception>

--- a/src/Elastic.OpenTelemetry/Extensions/OpenTelemetryBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/OpenTelemetryBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Runtime.CompilerServices;
 using Elastic.OpenTelemetry;
 using Elastic.OpenTelemetry.Configuration;
 using Elastic.OpenTelemetry.Core;
@@ -108,6 +109,7 @@ public static class OpenTelemetryBuilderExtensions
 		return WithElasticDefaultsCore(builder, new(options));
 	}
 
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	internal static IOpenTelemetryBuilder WithElasticDefaultsCore(
 		this IOpenTelemetryBuilder builder,
 		CompositeElasticOpenTelemetryOptions options)
@@ -133,44 +135,6 @@ public static class OpenTelemetryBuilderExtensions
 		}
 
 		return SignalBuilder.WithElasticDefaults(builder, options, null, builder.Services, ConfigureBuilder);
-	}
-
-	private static void ConfigureBuilder(IOpenTelemetryBuilder builder, BuilderState builderState, IServiceCollection? services)
-	{
-		var components = builderState.Components;
-		var options = builderState.Components.Options;
-
-		services?.Configure<OtlpExporterOptions>(OtlpExporterDefaults.OtlpExporterOptions);
-
-		if (options.Signals.HasFlagFast(Signals.Traces))
-		{
-			builder.WithTracing(b => b.WithElasticDefaults(components, builder.Services));
-		}
-		else
-		{
-			components.Logger.LogSignalDisabled(Signals.Traces.ToString().ToLower(),
-				nameof(IOpenTelemetryBuilder), builderState.InstanceIdentifier);
-		}
-
-		if (options.Signals.HasFlagFast(Signals.Metrics))
-		{
-			builder.WithMetrics(b => b.WithElasticDefaults(components, builder.Services));
-		}
-		else
-		{
-			components.Logger.LogSignalDisabled(Signals.Metrics.ToString().ToLower(),
-				nameof(IOpenTelemetryBuilder), builderState.InstanceIdentifier);
-		}
-
-		if (options.Signals.HasFlagFast(Signals.Logs))
-		{
-			builder.WithLogging(b => b.WithElasticDefaults(components, builder.Services));
-		}
-		else
-		{
-			components.Logger.LogSignalDisabled(Signals.Logs.ToString().ToLower(),
-				nameof(IOpenTelemetryBuilder), builderState.InstanceIdentifier);
-		}
 	}
 
 	/// <summary>
@@ -472,5 +436,41 @@ public static class OpenTelemetryBuilderExtensions
 			tpb.WithElasticDefaults(configuration, builder.Services);
 			configure?.Invoke(tpb);
 		});
+	}
+
+	private static void ConfigureBuilder(IOpenTelemetryBuilder builder, BuilderState builderState, IServiceCollection? services)
+	{
+		var components = builderState.Components;
+		var options = builderState.Components.Options;
+
+		if (options.Signals.HasFlagFast(Signals.Traces))
+		{
+			builder.WithTracing(tpb => tpb.WithElasticDefaults(components, builder.Services));
+		}
+		else
+		{
+			components.Logger.LogSignalDisabled(Signals.Traces.ToString().ToLower(),
+				nameof(IOpenTelemetryBuilder), builderState.InstanceIdentifier);
+		}
+
+		if (options.Signals.HasFlagFast(Signals.Metrics))
+		{
+			builder.WithMetrics(mpb => mpb.WithElasticDefaults(components, builder.Services));
+		}
+		else
+		{
+			components.Logger.LogSignalDisabled(Signals.Metrics.ToString().ToLower(),
+				nameof(IOpenTelemetryBuilder), builderState.InstanceIdentifier);
+		}
+
+		if (options.Signals.HasFlagFast(Signals.Logs))
+		{
+			builder.WithLogging(lpb => lpb.WithElasticDefaults(components, builder.Services));
+		}
+		else
+		{
+			components.Logger.LogSignalDisabled(Signals.Logs.ToString().ToLower(),
+				nameof(IOpenTelemetryBuilder), builderState.InstanceIdentifier);
+		}
 	}
 }

--- a/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
+++ b/src/Elastic.OpenTelemetry/Extensions/TracerProviderBuilderExtensions.cs
@@ -52,24 +52,6 @@ public static class TracerProviderBuilderExtensions
 		return WithElasticDefaultsCore(builder, null, null, null);
 	}
 
-	/// <summary>
-	/// <inheritdoc cref="WithElasticDefaults(TracerProviderBuilder)" />
-	/// </summary>
-	/// <param name="builder"><inheritdoc cref="WithElasticDefaults(TracerProviderBuilder)" path="/param[@name='builder']"/></param>
-	/// <param name="skipOtlpExporter">When registering Elastic defaults, skip automatic registration of the OTLP exporter for traces.</param>
-	/// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is null.</exception>
-	/// <returns><inheritdoc cref="WithElasticDefaults(TracerProviderBuilder)" /></returns>
-	public static TracerProviderBuilder WithElasticDefaults(this TracerProviderBuilder builder, bool skipOtlpExporter)
-	{
-#if NET
-        ArgumentNullException.ThrowIfNull(builder);
-#else
-		if (builder is null)
-			throw new ArgumentNullException(nameof(builder));
-#endif
-
-		return WithElasticDefaultsCore(builder, skipOtlpExporter ? CompositeElasticOpenTelemetryOptions.SkipOtlpOptions : null, null, null);
-	}
 
 	/// <summary>
 	/// <inheritdoc cref="WithElasticDefaults(TracerProviderBuilder)" />

--- a/tests/Elastic.OpenTelemetry.Tests/Configuration/CompositeElasticOpenTelemetryOptionsTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Configuration/CompositeElasticOpenTelemetryOptionsTests.cs
@@ -252,6 +252,43 @@ public class CompositeElasticOpenTelemetryOptionsTests(ITestOutputHelper output)
 	}
 
 	[Fact]
+	public void ExplicitOptions_TakePrecedenceOver_ConfigValues()
+	{
+		const string fileLogDirectory = "C:\\Temp";
+
+		var options = new ElasticOpenTelemetryOptions
+		{
+			LogDirectory = fileLogDirectory,
+			LogLevel = LogLevel.Critical
+		};
+
+		var json = $$"""
+					{
+						"Elastic": {
+							"OpenTelemetry": {
+								"LogDirectory": "C:\\Json",
+								"LogLevel": "Trace",
+								"ElasticDefaults": "All",
+								"SkipOtlpExporter": false,
+								"SkipInstrumentationAssemblyScanning": true
+							}
+						}
+					}
+					""";
+
+		var config = new ConfigurationBuilder()
+			.AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)))
+			.Build();
+
+		var sut = new CompositeElasticOpenTelemetryOptions(config, options);
+
+		Assert.Equal(fileLogDirectory, sut.LogDirectory);
+		Assert.Equal(LogLevel.Critical, sut.LogLevel);
+		Assert.False(sut.SkipOtlpExporter);
+		Assert.True(sut.SkipInstrumentationAssemblyScanning);
+	}
+
+	[Fact]
 	public void InitializedProperties_TakePrecedenceOver_EnvironmentValues()
 	{
 		const string fileLogDirectory = "C:\\Property";

--- a/tests/Elastic.OpenTelemetry.Tests/Diagnostics/LoggingTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Diagnostics/LoggingTests.cs
@@ -9,9 +9,6 @@ using Xunit.Abstractions;
 
 namespace Elastic.OpenTelemetry.Tests;
 
-// These run in a collection to avoid them running in parallel with other tests that may set the SharedComponents which would cause
-// these to fail.
-[Collection("Discrete SharedComponents")]
 public partial class LoggingTests(ITestOutputHelper output)
 {
 	[GeneratedRegex(@"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\]\[\d{6}\]\[-*\]\[Information\]\s+Elastic Distribution of OpenTelemetry \(EDOT\) \.NET:.*")]

--- a/tests/Elastic.OpenTelemetry.Tests/Extensions/HostApplicationBuilderTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Extensions/HostApplicationBuilderTests.cs
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+using Elastic.OpenTelemetry.Core;
+
+namespace Elastic.OpenTelemetry.Tests.Extensions;
+
+public class HostApplicationBuilderTests
+{
+	[Fact]
+	public void AddElasticOpenTelemetry_AppliesConfigAndOptions_InExpectedOrder()
+	{
+		const string fileLogDirectory = "C:\\Temp";
+
+		var options = new ElasticOpenTelemetryOptions
+		{
+			LogDirectory = fileLogDirectory,
+			LogLevel = LogLevel.Critical
+		};
+
+		var json = $$"""
+					{
+						"Elastic": {
+							"OpenTelemetry": {
+								"LogDirectory": "C:\\Json",
+								"LogLevel": "Trace",
+								"ElasticDefaults": "All",
+								"SkipOtlpExporter": true,
+								"SkipInstrumentationAssemblyScanning": true
+							}
+						}
+					}
+					""";
+
+		var builder = Host.CreateApplicationBuilder();
+
+		builder.Configuration.AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)));
+		builder.AddElasticOpenTelemetry(options);
+
+		var app = builder.Build();
+
+		var components = app.Services.GetRequiredService<ElasticOpenTelemetryComponents>();
+
+		Assert.Equal(fileLogDirectory, components.Options.LogDirectory);
+		Assert.Equal(LogLevel.Critical, components.Options.LogLevel);
+		Assert.True(components.Options.SkipOtlpExporter);
+		Assert.True(components.Options.SkipInstrumentationAssemblyScanning);
+	}
+}


### PR DESCRIPTION
This PR removes some redundant public extension methods for skipping OtlpExporter registration, preferring the extensions that accept an `ElasticOpenTelemetryOptions` instance. Removing these avoids confusion and simplifies documentation.

This also adds null checks and exception XML docs for the `ServiceCollectionExtensions`.