### PR TITLE
Disable `generateapichanges` for release

### DIFF
--- a/build/scripts/BuildInformation.fs
+++ b/build/scripts/BuildInformation.fs
@@ -28,13 +28,9 @@ type Paths =
     static member private SrcFolder = DirectoryInfo(Path.Combine(Paths.Root.FullName, "src"))
     static member SrcPath (t: string list) = DirectoryInfo(Path.Combine([Paths.SrcFolder.FullName] @ t |> List.toArray))
 
-
 type BuildConfiguration = 
     static member ValidateAssemblyName = false
     static member GenerateApiChanges = false
-    
-        
-        
 
 type Software =
     static member Organization = "elastic"

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -181,7 +181,7 @@ let Setup (parsed:ParseResults<Build>) =
         | Release -> 
             Build.Cmd 
                 [PristineCheck; Build; Redistribute]
-                [ValidateLicenses; GeneratePackages; ValidatePackages; GenerateReleaseNotes; GenerateApiChanges]
+                [ValidateLicenses; GeneratePackages; ValidatePackages; GenerateReleaseNotes]
                 release
 
         | Format -> Build.Step format


### PR DESCRIPTION
We'll enable post GA after fixing the script. This is not essential for the first GA release.