### PR TITLE
Remove invalid prefix from minver cmd

### DIFF
--- a/.github/workflows/bootstrap/action.yml
+++ b/.github/workflows/bootstrap/action.yml
@@ -50,7 +50,7 @@ runs:
       run: |
         dotnet --list-sdks
         dotnet tool restore
-        AGENT_VERSION=$(dotnet minver -t=v -p=canary.0 -v=e)
+        AGENT_VERSION=$(dotnet minver -p='canary.0' -v=e)
         echo "Version Number: ${AGENT_VERSION}"
         echo "AGENT_VERSION=${AGENT_VERSION}" >> $GITHUB_ENV
         echo "agent-version=${AGENT_VERSION}" >> $GITHUB_OUTPUT

--- a/tests/Elastic.OpenTelemetry.Tests/Diagnostics/LoggingTests.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/Diagnostics/LoggingTests.cs
@@ -11,6 +11,8 @@ namespace Elastic.OpenTelemetry.Tests;
 
 public partial class LoggingTests(ITestOutputHelper output)
 {
+	private readonly ITestOutputHelper _output = output;
+
 	[GeneratedRegex(@"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\]\[\d{6}\]\[-*\]\[Information\]\s+Elastic Distribution of OpenTelemetry \(EDOT\) \.NET:.*")]
 	private static partial Regex EdotPreamble();
 
@@ -20,33 +22,33 @@ public partial class LoggingTests(ITestOutputHelper output)
 	[Fact]
 	public void LoggingIsEnabled_WhenConfiguredViaTracerProviderBuilder()
 	{
-		var logger = new TestLogger(output);
+		var logger = new TestLogger(_output);
 		var options = new ElasticOpenTelemetryOptions { AdditionalLogger = logger, SkipOtlpExporter = true };
 
 		using var tracerProvider = Sdk.CreateTracerProviderBuilder()
 			.WithElasticDefaults(options)
 			.Build();
 
-		Assert.Single(logger.Messages.ToArray(), m => EdotPreamble().IsMatch(m));
+		Assert.Single(logger.Messages, m => EdotPreamble().IsMatch(m));
 	}
 
 	[Fact]
 	public void LoggingIsEnabled_WhenConfiguredViaMeterProviderBuilder()
 	{
-		var logger = new TestLogger(output);
+		var logger = new TestLogger(_output);
 		var options = new ElasticOpenTelemetryOptions { AdditionalLogger = logger, SkipOtlpExporter = true };
 
 		using var tracerProvider = Sdk.CreateMeterProviderBuilder()
 			.WithElasticDefaults(options)
 			.Build();
 
-		Assert.Single(logger.Messages.ToArray(), m => EdotPreamble().IsMatch(m));
+		Assert.Single(logger.Messages, m => EdotPreamble().IsMatch(m));
 	}
 
 	[Fact]
 	public void LoggingPreamble_IsSkipped_WhenReusingSharedComponents()
 	{
-		var logger = new TestLogger(output);
+		var logger = new TestLogger(_output);
 		var options = new ElasticOpenTelemetryOptions { AdditionalLogger = logger, SkipOtlpExporter = true };
 
 		using var tracerProvider = Sdk.CreateTracerProviderBuilder()
@@ -61,11 +63,9 @@ public partial class LoggingTests(ITestOutputHelper output)
 			.AddInMemoryExporter(new List<Metric>())
 			.Build();
 
-		var messages = logger.Messages.ToArray();
-
 		// On this builder, because we are reusing the same ElasticOpenTelemetryOptions, shared components will be available,
 		// and as such, the pre-amble should not be output a second time.
-		Assert.Single(messages, m => EdotPreamble().IsMatch(m));
-		Assert.Contains(messages, m => UsingSharedComponents().IsMatch(m));
+		Assert.Single(logger.Messages, m => EdotPreamble().IsMatch(m));
+		Assert.Contains(logger.Messages, m => UsingSharedComponents().IsMatch(m));
 	}
 }

--- a/tests/Elastic.OpenTelemetry.Tests/TestLogger.cs
+++ b/tests/Elastic.OpenTelemetry.Tests/TestLogger.cs
@@ -10,21 +10,21 @@ namespace Elastic.OpenTelemetry.Tests;
 public class TestLogger(ITestOutputHelper testOutputHelper) : ILogger
 {
 	private readonly List<string> _messages = [];
+	private readonly ITestOutputHelper _testOutputHelper = testOutputHelper;
 
 	public IReadOnlyCollection<string> Messages => _messages.AsReadOnly();
 
 	public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoopDisposable.Instance;
 
-	public bool IsEnabled(LogLevel logLevel)
-		=> true;
+	public bool IsEnabled(LogLevel logLevel) => true;
 
 	public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
 	{
 		var message = LogFormatter.Format(logLevel, eventId, state, exception, formatter);
 		_messages.Add(message);
-		testOutputHelper.WriteLine(message);
+		_testOutputHelper.WriteLine(message);
 		if (exception != null)
-			testOutputHelper.WriteLine(exception.ToString());
+			_testOutputHelper.WriteLine(exception.ToString());
 	}
 
 	private class NoopDisposable : IDisposable


### PR DESCRIPTION
Our tags are not prefixed with "v", so this command wasn't finding the expected version.