### PR TITLE
No longer default to IncludeScopes

### DIFF
--- a/src/Elastic.OpenTelemetry.Core/Diagnostics/LoggerMessages.cs
+++ b/src/Elastic.OpenTelemetry.Core/Diagnostics/LoggerMessages.cs
@@ -133,13 +133,17 @@ internal static partial class LoggerMessages
 
 
 
-	// We explictly reuse the same event ID and this is the same log message, but with different types for the structured data
-	[LoggerMessage(EventId = 50, EventName = "FoundTag", Level = LogLevel.Trace, Message = "{ProcessorName} found `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	[LoggerMessage(EventId = 50, EventName = "FoundTag", Level = LogLevel.Trace, Message = "{ProcessorName} found '{AttributeName}' attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void LogFoundTag(this ILogger logger, string processorName, string attributeName, object attributeValue);
 
-	// We explictly reuse the same event ID and this is the same log message, but with different types for the structured data
-	[LoggerMessage(EventId = 51, EventName = "SetTag", Level = LogLevel.Trace, Message = "{ProcessorName} set `{AttributeName}` attribute with value '{AttributeValue}' on the span.")]
+	[LoggerMessage(EventId = 51, EventName = "SetTag", Level = LogLevel.Trace, Message = "{ProcessorName} set '{AttributeName}' attribute with value '{AttributeValue}' on the span.")]
 	internal static partial void LogSetTag(this ILogger logger, string processorName, string attributeName, object attributeValue);
+
+
+
+
+	[LoggerMessage(EventId = 60, EventName = "DetectedIncludeScopes", Level = LogLevel.Warning, Message = "IncludeScopes is enabled and may cause export issues. See https://elastic.github.io/opentelemetry/edot-sdks/dotnet/troubleshooting.html#missing-log-records")]
+	internal static partial void LogDetectedIncludeScopesWarning(this ILogger logger);
 
 
 

--- a/src/Elastic.OpenTelemetry.Core/Extensions/OpenTelemetryLoggerOptionsExtensions.cs
+++ b/src/Elastic.OpenTelemetry.Core/Extensions/OpenTelemetryLoggerOptionsExtensions.cs
@@ -38,7 +38,12 @@ internal static class OpenTelemetryLoggerOptionsExtensions
 #endif
 
 		options.IncludeFormattedMessage = true;
-		options.IncludeScopes = true;
+
+		// IncludeScopes is disabled until we have a resolution to duplicate attributes
+		// See:
+		//   - https://github.com/open-telemetry/opentelemetry-dotnet/issues/4324
+		//   - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39304
+		// options.IncludeScopes = true;
 
 		logger.LogConfiguredSignalProvider(nameof(Signals.Logs), nameof(OpenTelemetryLoggerOptions), "<n/a>");
 	}


### PR DESCRIPTION
Due to spec non-compliance in the upstream SDK, this can cause issues when sent through the EDOT collector and the managed OTLP endpoint.

We'll reenable it in a future release once upstream is fixed.

Lessens the impact of #263. 

The main fix needs to occur upstream.