### PR TITLE
Skip E2E tests

### DIFF
--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -67,7 +67,7 @@ let private runTests suite _ =
             $"--logger:\"junit;%s{loggerPathArgs}\""
     let filterArgs =
         match suite with
-        | All -> []
+        | All -> [ "--filter"; "FullyQualifiedName!~.EndToEndTests" ]
         | Skip_All -> ["--filter"; "FullyQualifiedName~.SKIPPING.ALL.TESTS"]
         | Unit ->  [ "--filter"; "FullyQualifiedName~.Tests" ]
         | Integration -> [ "--filter"; "FullyQualifiedName~.IntegrationTests" ]


### PR DESCRIPTION
We no longer run these in CI as they were brittle and we plan an improved design.

For now, we will also skip these when running the tests using the build script so they do not fail locally.