### PR TITLE
Update CODEOWNERS: fabrizio is already in ingest-docs team; use apm-agent-net team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-*.md @theletterf @elastic/ingest-docs 
-/docs/ @theletterf @elastic/ingest-docs
-/.github/workflows @elastic/observablt-ci
+* @elastic/apm-agent-net
+/.github/workflows/ @elastic/apm-agent-net @elastic/observablt-ci
+*.md @elastic/ingest-docs
+/docs/ @elastic/ingest-docs


### PR DESCRIPTION
1. @theletterf This drops your user specifically as an owner, in favour of the existing ingest-docs team, which is what the other `elastic-otel-*/.github/CODEOWNERS` files do.
2. @stevejgordon Would you *like* to have `@elastic/apm-agent-net` team (https://github.com/orgs/elastic/teams/apm-agent-net) be an automatic reviewer for all PRs?  Totally your call.  The Java, Node and Python teams are doing this. EDOT PHP is *not*.