### PR TITLE
ci(trusted-publisher): use OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,16 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh release upload ${{ github.ref_name }} ${{ env.RELEASE_DISTRO }}
 
+    # Get a short-lived NuGet API key
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Release to Nuget (only for release events)
       if: ${{ github.event_name == 'release' }}
-      run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
+      run: dotnet nuget push '${{ env.RELEASE_PACKAGES }}' -k ${{steps.login.outputs.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
     
     - if: ${{ success() && github.event_name == 'release' }}
       uses: elastic/oblt-actions/slack/send@v1.13.0


### PR DESCRIPTION
See https://learn.microsoft.com/en-gb/nuget/nuget-org/trusted-publishing

As suggested, I created the new secret for the nuget user:

>  Recommended: use a secret like ${{ secrets.NUGET_USER }} for your nuget.org username (profile name), NOT your email address
