### PR TITLE
Remove redundant release steps

### DIFF
--- a/build/scripts/CommandLine.fs
+++ b/build/scripts/CommandLine.fs
@@ -32,8 +32,6 @@ type Build =
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] GeneratePackages
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] ValidateLicenses
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] ValidatePackages
-    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] GenerateReleaseNotes
-    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] GenerateApiChanges
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] Redistribute
     | [<CliPrefix(CliPrefix.None);SubCommand>] Release
     
@@ -62,10 +60,8 @@ with
             | GeneratePackages
             | ValidateLicenses
             | ValidatePackages
-            | GenerateReleaseNotes
             | Compile 
             | Redistribute
-            | GenerateApiChanges -> "Undocumented, dependent target"
             
             // flags
             | Single_Target -> "Runs the provided sub command without running their dependencies"

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,18 +8,6 @@
         "minver"
       ]
     },
-    "assembly-differ": {
-      "version": "0.17.0",
-      "commands": [
-        "assembly-differ"
-      ]
-    },
-    "release-notes": {
-      "version": "0.10.0",
-      "commands": [
-        "release-notes"
-      ]
-    },
     "nupkg-validator": {
       "version": "0.10.1",
       "commands": [


### PR DESCRIPTION
We generate release notes and breaking changes manually, for now. We would need to update the tooling based on the new docs structure if we wish to maintain the use of the automated tools. We can reintroduce when we're ready.