### PR TITLE
docs: add EDOT .NET v0.1.1 agent-skill callouts

### DIFF
--- a/docs/reference/edot-dotnet/migration.md
+++ b/docs/reference/edot-dotnet/migration.md
@@ -19,6 +19,10 @@ products:
 
 Compared to the Elastic APM .NET agent, the {{edot}} .NET presents a number of advantages:
 
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-migrate
+:::
+
 - No vendor lock-in through standardized concepts, supporting the use of multiple backend vendors or switching between them.
 - A single set of application APIs are required to instrument applications.
 - A wider pool of knowledge, experience and support is available across the OpenTelemetry community.

--- a/docs/reference/edot-dotnet/migration.md
+++ b/docs/reference/edot-dotnet/migration.md
@@ -32,6 +32,8 @@ Follow these steps to migrate from the legacy Elastic APM .NET agent to the {{ed
 
 :::{agent-skill}
 :url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-migrate
+
+Use this skill to migrate from the Elastic APM .NET agent to EDOT .NET.
 :::
 
 ### Manual instrumentation

--- a/docs/reference/edot-dotnet/migration.md
+++ b/docs/reference/edot-dotnet/migration.md
@@ -19,10 +19,6 @@ products:
 
 Compared to the Elastic APM .NET agent, the {{edot}} .NET presents a number of advantages:
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-migrate
-:::
-
 - No vendor lock-in through standardized concepts, supporting the use of multiple backend vendors or switching between them.
 - A single set of application APIs are required to instrument applications.
 - A wider pool of knowledge, experience and support is available across the OpenTelemetry community.
@@ -33,6 +29,10 @@ While you can use the [OpenTelemetry SDK for .NET](https://github.com/open-telem
 ## Migrating from Elastic .NET Agent [migrating-to-edot-net-from-elastic-net-agent]
 
 Follow these steps to migrate from the legacy Elastic APM .NET agent to the {{edot}} .NET.
+
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-migrate
+:::
 
 ### Manual instrumentation
 

--- a/docs/reference/edot-dotnet/setup/index.md
+++ b/docs/reference/edot-dotnet/setup/index.md
@@ -20,6 +20,8 @@ Learn how to set up and configure the {{edot}} .NET to instrument your applicati
 
 :::{agent-skill}
 :url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-instrument
+
+Use this skill to instrument .NET services with EDOT for tracing, metrics, and logs.
 :::
 
 ## Quickstart guide

--- a/docs/reference/edot-dotnet/setup/index.md
+++ b/docs/reference/edot-dotnet/setup/index.md
@@ -18,6 +18,10 @@ products:
 
 Learn how to set up and configure the {{edot}} .NET to instrument your application or service.
 
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-instrument
+:::
+
 ## Quickstart guide
 
 EDOT .NET is designed to be straightforward to integrate into your applications. Integration includes applications that have previously used the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/net/), those that are transitioning from the [Elastic APM Agent](apm-agent-dotnet://reference/index.md) and those introducing observability instrumentation for the first time. When the OpenTelemetry SDK or Elastic APM Agent are already in use, minor code changes are required at the point of registration. Refer to [Migration](/reference/edot-dotnet/migration.md) for more details.


### PR DESCRIPTION
## Summary
- Add an `{agent-skill}` callout for `observability/edot-dotnet-instrument` to the EDOT .NET setup page.
- Add an `{agent-skill}` callout for `observability/edot-dotnet-migrate` to the EDOT .NET migration page.
- Keep placement directly after the opening context, aligned with the docs-content rollout pattern.

## Test plan
- [x] Verified only the intended docs files changed.
- [x] Confirmed both callout URLs point to the new skills in `elastic/agent-skills` v0.1.1.
- [ ] Run docs preview.

Made with [Cursor](https://cursor.com)