### PR TITLE
[Test] Fix prerelease by building release artifacts before testing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -30,11 +30,13 @@ jobs:
         with:
           skip-cache: 'true'
 
+      # Run the release script to generate the distribution and packages
+      # The redistributable artifacts are needed for the test step, and the packages are needed for the publish steps that follow
+      - name: Release
+        run: ./build.sh release -c
+
       - name: Test
         run: ./build.sh test
-
-      - run: ./build.sh release -c
-        name: Release
         
       - name: Generate build provenance (Distribution)
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4


### PR DESCRIPTION
## Context

The prerelease.yml workflow runs on merge to main. Several test classes require redistributable zip artifacts to exist before they can run:

- ZipResolverVerificationTests (build verification)
- AutoInstrDistributionTests (integration)
- NuGetAutoInstrDistributionTests (integration)

These tests fail with "zip not found" / "Shared setup failed" errors because `./build.sh test` was running before `./build.sh release -c` (which produces the artifacts via its Redistribute dependency).

This PR moves the test after release which is cleaner because:
- Tests run against the same artifacts that will be published (validates the actual output)
- If tests fail, the publish steps still don't execute (GitHub Actions stops on failure)
- The philosophy fits the workflow: this is a post-merge canary, so building first then verifying is appropriate