### PR TITLE
Ensure that prerelease workflow tests don't clean after the release build

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -35,10 +35,10 @@ jobs:
       # Run the release script to generate the distribution and packages
       # The redistributable artifacts are needed for the test step, and the packages are needed for the publish steps that follow
       - name: Release
-        run: ./build.sh release -c
+        run: ./build.sh release
 
       - name: Test
-        run: ./build.sh test
+        run: ./build.sh test --skip-build --skip-restore
         
       - name: Generate build provenance (Distribution)
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4


### PR DESCRIPTION
Otherwise the nuget packages are no present ready for the attestations.