### PR TITLE
Improve diagnostic logging for loaded assemblies

### DIFF
--- a/src/Elastic.OpenTelemetry.Core/Diagnostics/LoadedAssemblyLogHelper.cs
+++ b/src/Elastic.OpenTelemetry.Core/Diagnostics/LoadedAssemblyLogHelper.cs
@@ -2,54 +2,88 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.OpenTelemetry.Core.Diagnostics;
 
-internal sealed class LoadedAssemblyLogHelper
+internal static class LoadedAssemblyLogHelper
 {
-	private static HashSet<string>? LoggedAssemblies;
+	// Assemblies with no independent diagnostic value — their identity is already captured by
+	// the .NET runtime version string, or they are infrastructure shims.
+	private static readonly HashSet<string> SkipByName = new(StringComparer.OrdinalIgnoreCase)
+		{ "mscorlib", "netstandard", "System.Private.CoreLib", "dotnet" };
 
-	internal static void LogLoadedAssemblies(ILogger logger)
+	// Key: "{name}|{assemblyVersion}" — includes version so that different versions of the same
+	// library loaded into separate AssemblyLoadContexts are each captured.
+	private static readonly ConcurrentDictionary<string, byte> Logged = new(StringComparer.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Subscribes to <see cref="AppDomain.AssemblyLoad"/> and logs assemblies as they load.
+	/// Also scans assemblies already loaded at call time. Subscription is established first
+	/// so no assembly loaded during the initial scan is missed.
+	/// </summary>
+	internal static void Subscribe(ILogger logger)
+	{
+		AppDomain.CurrentDomain.AssemblyLoad += (_, args) => TryLog(logger, args.LoadedAssembly);
+
+		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+			TryLog(logger, assembly);
+	}
+
+	[RequiresAssemblyFiles("Calls System.Reflection.Assembly.Location")]
+	private static void TryLog(ILogger logger, Assembly assembly)
 	{
 		if (!logger.IsEnabled(LogLevel.Debug))
 			return;
 
 		try
 		{
-			var assemblies = AppDomain.CurrentDomain.GetAssemblies()
-			.Where(a => a.GetName().Name?.StartsWith("OpenTelemetry", StringComparison.OrdinalIgnoreCase) == true)
-			.OrderBy(a => a.GetName().Name)
-			.ToList();
-
-			if (assemblies.Count == 0)
-			{
+			var assemblyName = assembly.GetName();
+			var name = assemblyName.Name;
+			if (string.IsNullOrEmpty(name) || SkipByName.Contains(name))
 				return;
-			}
 
-			LoggedAssemblies ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			// Key on name + assembly version: the same library name can appear multiple times in a
+			// process when different versions are loaded into separate AssemblyLoadContexts. Each
+			// distinct binding version is worth logging — version conflicts are a frequent support cause.
+			// Keying on assembly version (not informational version) matches the CLR binding identity.
+			var assemblyVersion = assemblyName.Version?.ToString() ?? "unknown";
+			if (!Logged.TryAdd($"{name}|{assemblyVersion}", 0))
+				return;
 
-			foreach (var assembly in assemblies)
+			// AssemblyInformationalVersion is the most precise — it carries the full semantic version
+			// including pre-release labels and git commit SHA for official packages.
+			// AssemblyVersion is logged separately because it is often locked to a major version for
+			// binary compatibility and may differ significantly from the actual release version.
+			var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+			var location = assembly.Location;
+
+			var tokenBytes = assemblyName.GetPublicKeyToken();
+			var publicKeyToken = tokenBytes is { Length: > 0 }
+				? BitConverter.ToString(tokenBytes).Replace("-", "").ToLowerInvariant()
+				: "null";
+
+			if (informationalVersion != null)
 			{
-				var assemblyName = assembly.GetName();
-				var name = assemblyName.Name;
-
-				if (name is null)
-					continue;
-
-				var fileVersion = assembly.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(System.Reflection.AssemblyFileVersionAttribute))?.ConstructorArguments[0].Value;
-
-				var version = fileVersion ?? assemblyName.Version?.ToString() ?? "unknown";
-
-				if (LoggedAssemblies != null && !LoggedAssemblies.Add(name))
-					continue;
-
-				logger.LogDebug("OpenTelemetry assembly found: {AssemblyName} (v{Version})", name, version);
+				logger.LogDebug(
+					"Assembly loaded: {AssemblyName}, AssemblyVersion={AssemblyVersion}, InformationalVersion={InformationalVersion}, PublicKeyToken={PublicKeyToken}, Location={Location}",
+					name, assemblyVersion, informationalVersion, publicKeyToken, location);
+			}
+			else
+			{
+				logger.LogDebug(
+					"Assembly loaded: {AssemblyName}, AssemblyVersion={AssemblyVersion}, PublicKeyToken={PublicKeyToken}, Location={Location}",
+					name, assemblyVersion, publicKeyToken, location);
 			}
 		}
-		catch (Exception ex)
+		catch
 		{
-			logger.LogError(ex, "Unable to log loaded assemblies");
+			// Never let assembly logging disturb the application.
 		}
 	}
 }

--- a/src/Elastic.OpenTelemetry.Core/Diagnostics/LoadedAssemblyLogHelper.cs
+++ b/src/Elastic.OpenTelemetry.Core/Diagnostics/LoadedAssemblyLogHelper.cs
@@ -2,11 +2,11 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using Elastic.OpenTelemetry.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.OpenTelemetry.Core.Diagnostics;
@@ -22,6 +22,8 @@ internal static class LoadedAssemblyLogHelper
 	// library loaded into separate AssemblyLoadContexts are each captured.
 	private static readonly ConcurrentDictionary<string, byte> Logged = new(StringComparer.OrdinalIgnoreCase);
 
+	private static int _subscribed;
+
 	/// <summary>
 	/// Subscribes to <see cref="AppDomain.AssemblyLoad"/> and logs assemblies as they load.
 	/// Also scans assemblies already loaded at call time. Subscription is established first
@@ -29,13 +31,19 @@ internal static class LoadedAssemblyLogHelper
 	/// </summary>
 	internal static void Subscribe(ILogger logger)
 	{
+		if (Interlocked.Exchange(ref _subscribed, 1) == 1)
+			return;
+
 		AppDomain.CurrentDomain.AssemblyLoad += (_, args) => TryLog(logger, args.LoadedAssembly);
 
 		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
 			TryLog(logger, assembly);
 	}
 
-	[RequiresAssemblyFiles("Calls System.Reflection.Assembly.Location")]
+	[UnconditionalSuppressMessage("SingleFile", "IL3000:AvoidAssemblyLocationInSingleFile",
+		Justification = "Assembly.Location is only accessed when RuntimeFeature.IsDynamicCodeSupported is true. " +
+		"In AoT/single-file scenarios the location is omitted and an empty string is handled gracefully, " +
+		"since this value is used only for diagnostic logging.")]
 	private static void TryLog(ILogger logger, Assembly assembly)
 	{
 		if (!logger.IsEnabled(LogLevel.Debug))
@@ -61,7 +69,11 @@ internal static class LoadedAssemblyLogHelper
 			// AssemblyVersion is logged separately because it is often locked to a major version for
 			// binary compatibility and may differ significantly from the actual release version.
 			var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-			var location = assembly.Location;
+#if NET
+			var location = RuntimeFeature.IsDynamicCodeSupported ? assembly.Location : string.Empty;
+#else
+			var location = assembly.IsDynamic ? string.Empty : assembly.Location;
+#endif
 
 			var tokenBytes = assemblyName.GetPublicKeyToken();
 			var publicKeyToken = tokenBytes is { Length: > 0 }
@@ -81,9 +93,9 @@ internal static class LoadedAssemblyLogHelper
 					name, assemblyVersion, publicKeyToken, location);
 			}
 		}
-		catch
+		catch (Exception ex)
 		{
-			// Never let assembly logging disturb the application.
+			logger.LogAssemblyIntrospectionFailed(ex);
 		}
 	}
 }

--- a/src/Elastic.OpenTelemetry.Core/Diagnostics/LoggerMessages.cs
+++ b/src/Elastic.OpenTelemetry.Core/Diagnostics/LoggerMessages.cs
@@ -65,6 +65,9 @@ internal static partial class LoggerMessages
 		"`ElasticUserAgentHandler` to set the EDOT .NET user agent.")]
 	public static partial void LogConfiguredOtlpExporterOptions(this ILogger logger, string signal);
 
+	[LoggerMessage(EventId = 13, EventName = "AssemblyIntrospectionFailed", Level = LogLevel.Warning,
+		Message = "Failed to log loaded assembly.")]
+	internal static partial void LogAssemblyIntrospectionFailed(this ILogger logger, Exception ex);
 
 
 

--- a/src/Elastic.OpenTelemetry.Core/SignalBuilder.cs
+++ b/src/Elastic.OpenTelemetry.Core/SignalBuilder.cs
@@ -144,7 +144,7 @@ internal static class SignalBuilder
 			// We will have flushed the deferred logger at this point so we can now use the final logger.
 			logger = components.Logger;
 
-			LoadedAssemblyLogHelper.LogLoadedAssemblies(components.Logger);
+			LoadedAssemblyLogHelper.Subscribe(components.Logger);
 
 			var builderContext = new BuilderContext<T>
 			{

--- a/tests/Elastic.OpenTelemetry.Tests/Diagnostics/event-id-snapshot.json
+++ b/tests/Elastic.OpenTelemetry.Tests/Diagnostics/event-id-snapshot.json
@@ -49,6 +49,10 @@
       "eventName": "ConfiguredOtlpExporterOptions"
     },
     {
+      "eventId": 13,
+      "eventName": "AssemblyIntrospectionFailed"
+    },
+    {
       "eventId": 20,
       "eventName": "ConfiguredSignalProvider"
     },


### PR DESCRIPTION
A small logging enhancement to track more loaded assemblies which may be diagnosticly helpful for complex scenarios. Also refactors slightly to a better design and support for multiple assemblies of different versions.