### PR TITLE
docs: rename EDOT to Elastic OTel .NET for 9.5 rebrand

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,4 @@
-project: 'EDOT .NET release notes'
+project: 'Elastic OTel .NET release notes'
 cross_links:
   - docs-content
   - opentelemetry
@@ -10,9 +10,9 @@ toc:
   - toc: reference/edot-dotnet
 subs:
   motlp: Elastic Cloud Managed OTLP Endpoint
-  edot: Elastic Distribution of OpenTelemetry
+  edot: Elastic OpenTelemetry
   ecloud:   "Elastic Cloud"
-  edot-cf:   "EDOT Cloud Forwarder"
+  edot-cf:   "Elastic Cloud Forwarder"
   ech:   "Elastic Cloud Hosted"
   ess:   "Elasticsearch Service"
   ece:   "Elastic Cloud Enterprise"

--- a/docs/reference/edot-dotnet/configuration.md
+++ b/docs/reference/edot-dotnet/configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Configuration
-description: Configure the Elastic Distribution of OpenTelemetry .NET (EDOT .NET) to send data to Elastic.
+description: Configure the Elastic OTel .NET to send data to Elastic.
 applies_to:
   stack:
   serverless:
@@ -14,9 +14,9 @@ products:
 
 ---
 
-# Configure the EDOT .NET SDK
+# Configure the Elastic OTel .NET SDK [configure-the-edot-net-sdk]
 
-Configure the {{edot}} .NET (EDOT .NET) to send data to Elastic.
+Configure the {{edot}} .NET to send data to Elastic.
 
 ## Configuration methods
 
@@ -25,7 +25,7 @@ including:
 
 * Setting [environment variables](#environment-variables).
 * Using the [`IConfiguration` integration](#iconfiguration-integration).
-* [Manually configuring](#manual-configuration) EDOT .NET.
+* [Manually configuring](#manual-configuration) Elastic OTel .NET.
 * [Central configuration](#central-configuration).
 
 Configuration options set manually in code take precedence over environment variables, and environment variables take precedence over configuration options set using the `IConfiguration` system. Central configuration is evaluated last and takes precedence over all other
@@ -33,17 +33,17 @@ configuration sources.
 
 ### Environment variables
 
-You can configure EDOT .NET using environment variables. This is a cross-platform way to configure EDOT .NET and is especially useful in containerized environments.
+You can configure Elastic OTel .NET using environment variables. This is a cross-platform way to configure Elastic OTel .NET and is especially useful in containerized environments.
 
-Environment variables are read at startup and can be used to configure EDOT .NET. For details of the various EDOT-specific options available and their corresponding environment variable names, see [Configuration options](#configuration-options).
+Environment variables are read at startup and can be used to configure Elastic OTel .NET. For details of the various Elastic-specific options available and their corresponding environment variable names, see [Configuration options](#configuration-options).
 
 All OpenTelemetry environment variables from the contrib SDK may also be used to configure the SDK behavior for features such as resources, samples and exporters.
 
 ### IConfiguration integration
 
-In applications that use the [".NET generic host"](https://learn.microsoft.com/dotnet/core/extensions/generic-host), such as [ASP.NET Core](https://learn.microsoft.com/aspnet/core/introduction-to-aspnet-core) and [worker services](https://learn.microsoft.com/dotnet/core/extensions/workers), EDOT .NET can be configured using the `IConfiguration` integration.
+In applications that use the [".NET generic host"](https://learn.microsoft.com/dotnet/core/extensions/generic-host), such as [ASP.NET Core](https://learn.microsoft.com/aspnet/core/introduction-to-aspnet-core) and [worker services](https://learn.microsoft.com/dotnet/core/extensions/workers), Elastic OTel .NET can be configured using the `IConfiguration` integration.
 
-When using an `IHostApplicationBuilder` in modern ASP.NET Core applications, the `AddElasticOpenTelemetry` extension method turns on EDOT .NET and configuration from `IHostApplicationBuilder.Configuration` is passed in automatically. For example:
+When using an `IHostApplicationBuilder` in modern ASP.NET Core applications, the `AddElasticOpenTelemetry` extension method turns on Elastic OTel .NET and configuration from `IHostApplicationBuilder.Configuration` is passed in automatically. For example:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -70,7 +70,7 @@ For example, you can define the configuration for the {{edot}} .NET in the `apps
 This example sets the file log directory to `C:\Logs` which activates diagnostic file logging.
 :::
 
-Configuration parsed from the `Elastic:OpenTelemetry` section of the `IConfiguration` instance is bound to the `ElasticOpenTelemetryOptions` instance used to configure EDOT .NET.
+Configuration parsed from the `Elastic:OpenTelemetry` section of the `IConfiguration` instance is bound to the `ElasticOpenTelemetryOptions` instance used to configure Elastic OTel .NET.
 
 In situations where the application might not depend on the hosting APIs, but uses the dependency injection APIs instead, an `IConfiguration` instance can be passed in manually. This is usually the case with console applications. For example:
 
@@ -90,7 +90,7 @@ To learn more about the Microsoft configuration system, see [Configuration in AS
 
 ### Manual configuration
 
-In all other scenarios, you can configure EDOT .NET manually in code.
+In all other scenarios, you can configure Elastic OTel .NET manually in code.
 
 Create an instance of `ElasticOpenTelemetryOptions` and pass it to an overload of the `WithElasticDefaults` extension methods available on the `IHostApplicationBuilder`, the `IServiceCollection` and the specific signal providers such as `TracerProviderBuilder`.
 
@@ -117,18 +117,18 @@ using var sdk = OpenTelemetrySdk.Create(builder => builder
 
 ## Configuration options
 
-Because the {{edot}} .NET (EDOT .NET) is an extension of the [OpenTelemetry .NET SDK](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation), it supports both:
+Because the {{edot}} .NET is an extension of the [OpenTelemetry .NET SDK](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation), it supports both:
 
 * General OpenTelemetry SDK configuration options
-* Elastic-specific configuration options that are only available when using EDOT .NET
+* Elastic-specific configuration options that are only available when using Elastic OTel .NET
 
 ### OpenTelemetry SDK configuration options
 
-EDOT .NET supports all configuration options listed in the [OpenTelemetry General SDK Configuration documentation](https://opentelemetry.io/docs/languages/sdk-configuration/general/).
+Elastic OTel .NET supports all configuration options listed in the [OpenTelemetry General SDK Configuration documentation](https://opentelemetry.io/docs/languages/sdk-configuration/general/).
 
 ### Elastic-specific configuration options
 
-EDOT .NET supports the following Elastic-specific options.
+Elastic OTel .NET supports the following Elastic-specific options.
 
 #### `LogDirectory`
 
@@ -147,7 +147,7 @@ A string specifying the output directory where the {{edot}} .NET writes diagnost
 * Type: String
 * Default: `Information`
 
-Sets the logging level for EDOT .NET. Valid options are `Critical`, `Error`, `Warning`, `Information`, `Debug`, `Trace`, and `None`. `None` disables the logging.
+Sets the logging level for Elastic OTel .NET. Valid options are `Critical`, `Error`, `Warning`, `Information`, `Debug`, `Trace`, and `None`. `None` disables the logging.
 
 | Configuration method | Key |
 |---|---|
@@ -173,7 +173,7 @@ Valid options are `file`, `stdout` and `none`. `None` disables the logging.
 * Type: Bool
 * Default: `false`
 
-Allows EDOT .NET to be used with its defaults, but without enabling the export of telemetry data to
+Allows Elastic OTel .NET to be used with its defaults, but without enabling the export of telemetry data to
 an OTLP endpoint. This can be useful when you want to test applications without sending telemetry data.
 
 | Configuration method | Key |
@@ -186,7 +186,7 @@ an OTLP endpoint. This can be useful when you want to test applications without 
 * Type: Bool
 * Default: `false`
 
-Allows EDOT .NET to be used without the instrumentation assembly scanning feature turned on. This prevents the automatic registration of instrumentation from referenced [OpenTelemetry contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib) instrumentation packages.
+Allows Elastic OTel .NET to be used without the instrumentation assembly scanning feature turned on. This prevents the automatic registration of instrumentation from referenced [OpenTelemetry contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib) instrumentation packages.
 
 | Configuration method | Key |
 |---|---|
@@ -198,7 +198,7 @@ Allows EDOT .NET to be used without the instrumentation assembly scanning featur
 * Type: String
 * Default: `string.Empty`
 
-The OpAMP server endpoint used for [central configuration](#central-configuration). When set, EDOT .NET connects to the specified endpoint to receive remote configuration updates. Setting this option also requires a service name. EDOT .NET resolves the service name from `OTEL_SERVICE_NAME` first; if that is not set, it falls back to the `service.name` key within `OTEL_RESOURCE_ATTRIBUTES`. If neither is configured, central configuration is silently deactivated.
+The OpAMP server endpoint used for [central configuration](#central-configuration). When set, Elastic OTel .NET connects to the specified endpoint to receive remote configuration updates. Setting this option also requires a service name. Elastic OTel .NET resolves the service name from `OTEL_SERVICE_NAME` first; if that is not set, it falls back to the `service.name` key within `OTEL_RESOURCE_ATTRIBUTES`. If neither is configured, central configuration is silently deactivated.
 
 | Configuration method | Key |
 |---|---|
@@ -236,10 +236,10 @@ HTTPS endpoints are supported for the OpAMP connection used by [central configur
 ## Central configuration
 
 :::{note}
-Central configuration is available since 1.4.0 of EDOT .NET.
+Central configuration is available since 1.4.0 of Elastic OTel .NET.
 :::
 
-Central configuration allows you to manage EDOT .NET settings remotely without redeploying. When turned on, EDOT .NET connects to an OpAMP-compatible server (the EDOT Collector configured with the Elastic APM Config Extension) and receives configuration at startup from Elastic Observability.
+Central configuration allows you to manage Elastic OTel .NET settings remotely without redeploying. When turned on, Elastic OTel .NET connects to an OpAMP-compatible server (the Elastic Agent configured with the Elastic APM Config Extension) and receives configuration at startup from Elastic Observability.
 
 Central configuration takes precedence over all other configuration sources (environment variables and `IConfiguration`). When a remote value is removed, the locally configured value is restored on the next agent startup.
 
@@ -281,7 +281,7 @@ var options = new ElasticOpenTelemetryOptions
 };
 ```
 
-Central configuration also requires a service name so that EDOT .NET can identify itself to the OpAMP server. EDOT .NET resolves the service name in the following order:
+Central configuration also requires a service name so that Elastic OTel .NET can identify itself to the OpAMP server. Elastic OTel .NET resolves the service name in the following order:
 
 1. `OTEL_SERVICE_NAME` environment variable (or the same key in `IConfiguration`)
 2. The `service.name` key within `OTEL_RESOURCE_ATTRIBUTES` (used as a fallback if `OTEL_SERVICE_NAME` is not set)

--- a/docs/reference/edot-dotnet/index.md
+++ b/docs/reference/edot-dotnet/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT .NET
-description: The Elastic Distribution of OpenTelemetry (EDOT) .NET provides an extension of the OpenTelemetry SDK for .NET, configured for the best experience with Elastic Observability. 
+navigation_title: Elastic OTel .NET
+description: The Elastic OTel .NET provides an extension of the OpenTelemetry SDK for .NET, configured for the best experience with Elastic Observability.
 applies_to:
   stack:
   serverless:
@@ -14,17 +14,17 @@ products:
 
 ---
 
-# Elastic Distribution of OpenTelemetry .NET
+# Elastic OTel .NET [elastic-distribution-of-opentelemetry-net]
 
-The {{edot}} (EDOT) .NET provides an extension of the [OpenTelemetry SDK for .NET](https://opentelemetry.io/docs/languages/net), configured for the best experience with Elastic Observability. 
+The {{edot}} .NET provides an extension of the [OpenTelemetry SDK for .NET](https://opentelemetry.io/docs/languages/net), configured for the best experience with Elastic Observability.
 
-Use EDOT .NET to start the OpenTelemetry SDK with your .NET application, and automatically capture tracing data, performance metrics, and logs. Traces, metrics, and logs can be sent to any OpenTelemetry Protocol (OTLP) Collector you choose.
+Use Elastic OTel .NET to start the OpenTelemetry SDK with your .NET application, and automatically capture tracing data, performance metrics, and logs. Traces, metrics, and logs can be sent to any OpenTelemetry Protocol (OTLP) Collector you choose.
 
 A goal of this distribution is to avoid introducing proprietary concepts in addition to those defined by the wider OpenTelemetry community. For any additional features introduced, Elastic aims at contributing them back to the contrib OpenTelemetry project.
 
 ## Features
 
-In addition to all the features of OpenTelemetry .NET, with EDOT .NET you have access to the following:
+In addition to all the features of OpenTelemetry .NET, with Elastic OTel .NET you have access to the following:
 
 * Improvements and bug fixes contributed by the Elastic team before the changes are available in contrib OpenTelemetry repositories.
 * Optional features that can enhance OpenTelemetry data that is being sent to Elastic.
@@ -36,4 +36,4 @@ Follow the step-by-step instructions in [Setup](/reference/edot-dotnet/setup/ind
 
 ## Release notes
 
-For the latest release notes, including known issues, deprecations, and breaking changes, refer to [EDOT .NET release notes](/release-notes/index.md)
+For the latest release notes, including known issues, deprecations, and breaking changes, refer to [Elastic OTel .NET release notes](/release-notes/index.md)

--- a/docs/reference/edot-dotnet/migration.md
+++ b/docs/reference/edot-dotnet/migration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Migration
-description: Migrate from the Elastic APM .NET agent to the Elastic Distribution of OpenTelemetry .NET (EDOT .NET).
+description: Migrate from the Elastic APM .NET agent to Elastic OTel .NET.
 applies_to:
   stack:
   serverless:
@@ -15,7 +15,7 @@ products:
 
 ---
 
-# Migrate to EDOT .NET from the Elastic APM .NET agent
+# Migrate to Elastic OTel .NET from the Elastic APM .NET agent [migrate-to-edot-net-from-the-elastic-apm-net-agent]
 
 Compared to the Elastic APM .NET agent, the {{edot}} .NET presents a number of advantages:
 
@@ -24,7 +24,7 @@ Compared to the Elastic APM .NET agent, the {{edot}} .NET presents a number of a
 - A wider pool of knowledge, experience and support is available across the OpenTelemetry community.
 - Efficient data collection and advanced data processing opportunities.
 
-While you can use the [OpenTelemetry SDK for .NET](https://github.com/open-telemetry/opentelemetry-dotnet) to directly export data to an Elastic Observability backend, some capabilities of the Elastic tooling might not be able to function as intended. Use the {{edot}} (EDOT) language SDK and the [{{edot}} Collector](elastic-agent://reference/edot-collector/index.md) for the best experience.
+While you can use the [OpenTelemetry SDK for .NET](https://github.com/open-telemetry/opentelemetry-dotnet) to directly export data to an Elastic Observability backend, some capabilities of the Elastic tooling might not be able to function as intended. Use the {{edot}} language SDK and the [{{agent}}](elastic-agent://reference/edot-collector/index.md) for the best experience.
 
 ## Migrating from Elastic .NET Agent [migrating-to-edot-net-from-elastic-net-agent]
 
@@ -33,7 +33,7 @@ Follow these steps to migrate from the legacy Elastic APM .NET agent to the {{ed
 :::{agent-skill}
 :url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-migrate
 
-Use this skill to migrate from the Elastic APM .NET agent to EDOT .NET.
+Use this skill to migrate from the Elastic APM .NET agent to Elastic OTel .NET.
 :::
 
 ### Manual instrumentation
@@ -108,7 +108,7 @@ The preceding code uses the `SetTag` method to "activity" variable may be assign
 
 ### Agent registration
 
-After migrating any manual instrumentation from the Elastic APM Agent public API to the Microsoft `Activity` API, the final step is to switch the observation and export of telemetry signals from the APM Agent to EDOT .NET.
+After migrating any manual instrumentation from the Elastic APM Agent public API to the Microsoft `Activity` API, the final step is to switch the observation and export of telemetry signals from the APM Agent to Elastic OTel .NET.
 
 The steps vary by project template. In all cases, you need to add the `Elastic.Opentelemetry` [NuGet package](https://www.nuget.org/packages/Elastic.OpenTelemetry)
 to your project:
@@ -138,7 +138,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAllElasticApm();
 ```
 
-To switch to using EDOT .NET, replace the preceding code:
+To switch to using Elastic OTel .NET, replace the preceding code:
 
 ```csharp
 using OpenTelemetry;
@@ -149,7 +149,7 @@ builder.AddElasticOpenTelemetry(b => b
    .WithTracing(t => t.AddSource("MyAppInstrumentation")));
 ```
 
-The previous snippet adds one additional source to be observed, which matches the name you gave to the `ActivitySource` defined earlier. It also uses the `AddElasticOpenTelemetry` extension method for the `IHostApplicationBuilder`. By default, EDOT .NET is configured to observe the most common instrumentation and export data through OTLP. Refer to [Opinionated defaults](/reference/edot-dotnet/setup/edot-defaults.md) for more information.
+The previous snippet adds one additional source to be observed, which matches the name you gave to the `ActivitySource` defined earlier. It also uses the `AddElasticOpenTelemetry` extension method for the `IHostApplicationBuilder`. By default, Elastic OTel .NET is configured to observe the most common instrumentation and export data through OTLP. Refer to [Opinionated defaults](/reference/edot-dotnet/setup/edot-defaults.md) for more information.
 
 Configuration of the APM Agent is likely to have been achieved using environment variables or by providing settings using the `appsettings.json` file, typical for ASP.NET Core applications:
 
@@ -174,7 +174,7 @@ The OpenTelemetry SDK is generally configured using environment variables. For t
 
 The required values for the endpoint and headers can be obtained from your Elastic Observability instance. After you've migrated, you can remove the Elastic APM Agent NuGet from your application.
 
-For more details on registering and configuring EDOT. NET, see the [quickstart](/reference/edot-dotnet/setup/index.md) documentation.
+For more details on registering and configuring Elastic OTel .NET, see the [quickstart](/reference/edot-dotnet/setup/index.md) documentation.
 
 ### Zero-code auto instrumentation
 
@@ -193,31 +193,31 @@ When using the Elastic APM Agent profiler auto-instrumentation functionality, th
 | All            | ELASTIC_APM_SERVER_URL              | The URL of the APM Server.                      |
 | All            | ELASTIC_APM_SECRET_TOKEN            | The secret used to authenticate with APM server.|
 
-To switch to the EDOT .NET zero-code auto instrumentation, update the `COR_*` and `CORECLR_*` environment variables to point to the Elastic redistribution of the OpenTelemetry auto-instrumentation profiler.
+To switch to the Elastic OTel .NET zero-code auto instrumentation, update the `COR_*` and `CORECLR_*` environment variables to point to the Elastic redistribution of the OpenTelemetry auto-instrumentation profiler.
 
-Follow the steps in [Using EDOT .NET zero-code instrumentation](/reference/edot-dotnet/setup/zero-code.md) to configure the profiler.
+Follow the steps in [Using Elastic OTel .NET zero-code instrumentation](/reference/edot-dotnet/setup/zero-code.md) to configure the profiler.
 
 ### Limitations
 
-Elastic APM Agent includes several features that are not currently supported when using EDOT .NET. Each of these are being assessed and may be included in contributions to OpenTelemetry or as value-add features of EDOT .NET in future releases.
+Elastic APM Agent includes several features that are not currently supported when using Elastic OTel .NET. Each of these are being assessed and may be included in contributions to OpenTelemetry or as value-add features of Elastic OTel .NET in future releases.
 
 #### Stacktrace capture
 
-The [stacktrace capture](apm-agent-dotnet://reference/config-stacktrace.md) feature from Elastic APM .NET agent is not currently available in EDOT .NET.
+The [stacktrace capture](apm-agent-dotnet://reference/config-stacktrace.md) feature from Elastic APM .NET agent is not currently available in Elastic OTel .NET.
 
 #### Central and dynamic configuration
 
-Currently EDOT .NET does not have an equivalent of the [central configuration feature](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) that the Elastic APM .NET agent supports. 
+Currently Elastic OTel .NET does not have an equivalent of the [central configuration feature](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) that the Elastic APM .NET agent supports.
 
-When using EDOT .NET, all the configurations are static and should be provided to the application with other configurations, such as environment variables.
+When using Elastic OTel .NET, all the configurations are static and should be provided to the application with other configurations, such as environment variables.
 
 #### Span compression
 
-EDOT .NET does not implement [span compression](docs-content://solutions/observability/apm/spans.md#apm-spans-span-compression).
+Elastic OTel .NET does not implement [span compression](docs-content://solutions/observability/apm/spans.md#apm-spans-span-compression).
 
 ## Migrate from the .NET SDK [migrating-to-edot-net-from-the-upstream-opentelemetry-net-sdk]
 
-EDOT .NET require minimal code changes to migrate from the OpenTelemetry SDK for .NET. The distribution [opinionated defaults](/reference/edot-dotnet/setup/edot-defaults.md) simplify the amount of code required to get started with OpenTelemetry in .NET applications.
+Elastic OTel .NET require minimal code changes to migrate from the OpenTelemetry SDK for .NET. The distribution [opinionated defaults](/reference/edot-dotnet/setup/edot-defaults.md) simplify the amount of code required to get started with OpenTelemetry in .NET applications.
 
 In an application which already uses the OpenTelemetry SDK, the following code is an example of how this would be registered and enabled in an ASP.NET Core application.
 
@@ -259,9 +259,9 @@ reference to your project file:
 Replace the `<LATEST>` version placeholder with the [latest available package from NuGet.org](https://www.nuget.org/packages/Elastic.OpenTelemetry).
 :::
 
-EDOT .NET includes a transitive dependency on the OpenTelemetry SDK, so you do not need to add the OpenTelemetry SDK package to your project directly. However, you can explicitly add the OpenTelemetry SDK as a dependency if you want to opt into newer SDK versions.
+Elastic OTel .NET includes a transitive dependency on the OpenTelemetry SDK, so you do not need to add the OpenTelemetry SDK package to your project directly. However, you can explicitly add the OpenTelemetry SDK as a dependency if you want to opt into newer SDK versions.
 
-Due to the EDOT .NET defaults, less code is required to achieve the same instrumentation behavior that the previous code snippet configured for the OpenTelemetry SDK. For example:
+Due to the Elastic OTel .NET defaults, less code is required to achieve the same instrumentation behavior that the previous code snippet configured for the OpenTelemetry SDK. For example:
 
 ```csharp
 using OpenTelemetry;
@@ -272,7 +272,7 @@ builder.AddElasticOpenTelemetry(b => b
     .WithTracing(t => t.AddSource("AppInstrumentation")));
 ```
 
-EDOT .NET activates all signals by default, so the registration code is less verbose. EDOT .NET also performs instrumentation assembly scanning to automatically add instrumentation from any contrib libraries that it finds deployed with the application. All that is required is the installation of the relevant instrumentation NuGet packages.
+Elastic OTel .NET activates all signals by default, so the registration code is less verbose. Elastic OTel .NET also performs instrumentation assembly scanning to automatically add instrumentation from any contrib libraries that it finds deployed with the application. All that is required is the installation of the relevant instrumentation NuGet packages.
 
 :::{warning}
 Instrumentation assembly scanning is not supported for applications using native [AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot) compilation.
@@ -280,10 +280,10 @@ Instrumentation assembly scanning is not supported for applications using native
 
 ### Zero-code instrumentation
 
-EDOT .NET ships with a lightly modified redistribution of the OpenTelemetry SDK installation script. To instrument a .NET application automatically, download and run the installer script for your operating system from the latest [release](https://github.com/elastic/elastic-otel-dotnet/releases).
+Elastic OTel .NET ships with a lightly modified redistribution of the OpenTelemetry SDK installation script. To instrument a .NET application automatically, download and run the installer script for your operating system from the latest [release](https://github.com/elastic/elastic-otel-dotnet/releases).
 
 Refer to the OpenTelemetry SDK documentation for [.NET zero-code instrumentation](https://opentelemetry.io/docs/zero-code/net) for more examples of using the installation script.
 
 ## Troubleshooting
 
-If you're encountering issues during migration, refer to the [EDOT .NET troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/dotnet/index.md).
+If you're encountering issues during migration, refer to the [Elastic OTel .NET troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/dotnet/index.md).

--- a/docs/reference/edot-dotnet/setup/aspnet.md
+++ b/docs/reference/edot-dotnet/setup/aspnet.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: ASP.NET
-description: EDOT .NET can be used with ASP.NET applications by registering the OpenTelemetry SDK TelemetryHttpModule.
+description: Elastic OTel .NET can be used with ASP.NET applications by registering the OpenTelemetry SDK TelemetryHttpModule.
 applies_to:
   stack:
   serverless:
@@ -14,9 +14,9 @@ products:
 
 ---
 
-# Set up EDOT .NET for ASP.NET applications on .NET Framework
+# Set up Elastic OTel .NET for ASP.NET applications on .NET Framework [set-up-edot-net-for-aspnet-applications-on-net-framework]
 
-You can use EDOT .NET with ASP.NET applications by registering the OpenTelemetry SDK TelemetryHttpModule.
+You can use Elastic OTel .NET with ASP.NET applications by registering the OpenTelemetry SDK TelemetryHttpModule.
 
 ## Install the NuGet packages
 
@@ -31,7 +31,7 @@ reference to your project file:
 Replace the `<LATEST>` version placeholder with the [latest available package from NuGet.org](https://www.nuget.org/packages/Elastic.OpenTelemetry).
 :::
 
-EDOT .NET includes a transitive dependency on the OpenTelemetry SDK, so you do not need to add the OpenTelemetry SDK package to your project directly. However,
+Elastic OTel .NET includes a transitive dependency on the OpenTelemetry SDK, so you do not need to add the OpenTelemetry SDK package to your project directly. However,
 you can explicitly add the OpenTelemetry SDK as a dependency if you want to opt into newer SDK versions.
 
 For ASP.NET applications, you also need to install the contrib instrumentation library. Add the `OpenTelemetry.Instrumentation.AspNet` [NuGet package](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet) reference to your project file:
@@ -60,7 +60,7 @@ Next, modify your `Web.Config` file to add a required HttpModule:
 </system.webServer>
 ```
 
-## Register the EDOT .NET and OpenTelemetry SDK
+## Register the Elastic OTel .NET and OpenTelemetry SDK [register-the-edot-net-and-opentelemetry-sdk]
 
 Finally, initialize ASP.NET instrumentation in your `Global.asax.cs` file along with other OpenTelemetry initialization:
 
@@ -105,10 +105,10 @@ The preceding code:
 1. Imports the required types from the `OpenTelemetry` namespace.
 2. Creates an instance of the `OpenTelemetrySdk` using its factory `Create` method.
 3. Configures the `IOpenTelemetryBuilder` by passing a lambda.
-4. Enables EDOT .NET and its [opinionated defaults](edot-defaults.md) by calling `WithElasticDefaults` on the `IOpenTelemetryBuilder`.
+4. Enables Elastic OTel .NET and its [opinionated defaults](edot-defaults.md) by calling `WithElasticDefaults` on the `IOpenTelemetryBuilder`.
 5. Calls `ConfigureResource` to configure the name for the service.
 
-By default, EDOT .NET uses instrumentation assembly scanning and will detect the `OpenTelemetry.Instrumentation.AspNet` instrumentation, registering it with the OpenTelemetry SDK. Traces for ASP.NET requests are automatically observed and exported over OTLP without further configuration.
+By default, Elastic OTel .NET uses instrumentation assembly scanning and will detect the `OpenTelemetry.Instrumentation.AspNet` instrumentation, registering it with the OpenTelemetry SDK. Traces for ASP.NET requests are automatically observed and exported over OTLP without further configuration.
 
 ## Configure environment variables
 

--- a/docs/reference/edot-dotnet/setup/aspnetcore.md
+++ b/docs/reference/edot-dotnet/setup/aspnetcore.md
@@ -13,5 +13,5 @@ products:
 
 ---
 
-# Set up EDOT .NET for ASP.NET Core applications
+# Set up Elastic OTel .NET for ASP.NET Core applications [set-up-edot-net-for-aspnet-core-applications]
 

--- a/docs/reference/edot-dotnet/setup/console.md
+++ b/docs/reference/edot-dotnet/setup/console.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Console applications
-description: Learn how to instrument console applications using the Elastic Distribution of OpenTelemetry .NET.
+description: Learn how to instrument console applications using Elastic OTel .NET.
 applies_to:
   stack:
   serverless:
@@ -14,7 +14,7 @@ products:
 
 ---
 
-# Set up EDOT .NET for console applications
+# Set up Elastic OTel .NET for console applications [set-up-edot-net-for-console-applications]
 
 You can instrument console applications using the {{edot}} .NET. Applications running without a [host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) can initialize OpenTelemetry manually. For example:
 
@@ -30,7 +30,7 @@ The preceding code:
 1. Imports the required types from the `OpenTelemetry` namespace.
 2. Creates an instance of the `OpenTelemetrySdk` using its factory `Create` method.
 3. Configures the `IOpenTelemetryBuilder` by passing a lambda.
-4. Enables EDOT .NET and its [opinionated defaults](edot-defaults.md) by calling `WithElasticDefaults` on the `IOpenTelemetryBuilder`.
+4. Enables Elastic OTel .NET and its [opinionated defaults](edot-defaults.md) by calling `WithElasticDefaults` on the `IOpenTelemetryBuilder`.
 
 When building console applications, consider using the features provided by [`Microsoft.Extensions.Hosting`](https://www.nuget.org/packages/microsoft.extensions.hosting) as this turns on dependency injection and logging capabilities.
 
@@ -75,9 +75,9 @@ When calling `OpenTelemetrySdk.Create` a dedicated `IServiceCollection` and `ISe
 
 Replace the `{MyServerlessEndpoint}` and `{MyEncodedApiKey}` placeholders above with the values provided by your Elastic Observability backend.
 
-### Configure EDOT .NET
+### Configure Elastic OTel .NET [configure-edot-net]
 
-Several configuration settings are available to control the additional features offered by EDOT .NET. These might be configured using environment variables, `IConfiguration` and/or code-based configuration. Refer to [Configuration](/reference/edot-dotnet/configuration.md) documentation for more details.
+Several configuration settings are available to control the additional features offered by Elastic OTel .NET. These might be configured using environment variables, `IConfiguration` and/or code-based configuration. Refer to [Configuration](/reference/edot-dotnet/configuration.md) documentation for more details.
 
 As an example, manual code-based configuration can be used to disable the instrumentation assembly scanning feature.
 
@@ -104,7 +104,7 @@ The preceding code:
 2. Configures `SkipInstrumentationAssemblyScanning` as `true` to disable the assembly scanning feature.
 3. Passes the `ElasticOpenTelemetryOptions` from the `options` variable into the `WithElasticDefaults` method.
 
-You can also use `IConfiguration` to control EDOT .NET.
+You can also use `IConfiguration` to control Elastic OTel .NET.
 
 ```csharp
 using OpenTelemetry;

--- a/docs/reference/edot-dotnet/setup/edot-defaults.md
+++ b/docs/reference/edot-dotnet/setup/edot-defaults.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Opinionated defaults
-description: When using EDOT .NET, Elastic defaults for tracing, metrics and logging are applied. These defaults are designed to provide a faster getting started experience by automatically enabling data collection from telemetry signals without requiring as much up-front code as the OpenTelemetry SDK.
+description: When using Elastic OTel .NET, Elastic defaults for tracing, metrics, and logging are applied to provide a faster getting started experience with less up-front code than the OpenTelemetry SDK.
 applies_to:
   stack:
   serverless:
@@ -14,9 +14,9 @@ products:
 
 ---
 
-# EDOT .NET opinionated defaults
+# Elastic OTel .NET opinionated defaults [edot-net-opinionated-defaults]
 
-When using EDOT .NET, Elastic defaults for tracing, metrics and logging are applied. These defaults are designed to provide a faster getting started experience by automatically enabling data collection from telemetry signals without requiring as much up-front code as the OpenTelemetry SDK. This has the positive side effect of reducing the
+When using Elastic OTel .NET, Elastic defaults for tracing, metrics and logging are applied. These defaults are designed to provide a faster getting started experience by automatically enabling data collection from telemetry signals without requiring as much up-front code as the OpenTelemetry SDK. This has the positive side effect of reducing the
 boilerplate code you must maintain in your application. These defaults should be satisfactory for most applications but can be overridden for advanced use cases.
 
 ## Defaults for all signals
@@ -27,14 +27,14 @@ When using any of the following registration extension methods:
 - `IServiceCollection.AddElasticOpenTelemetry`
 - `IOpenTelemetryBuilder.WithElasticDefaults`
 
-EDOT .NET turns on:
+Elastic OTel .NET turns on:
 
 - Observation of all signals (tracing, metrics and logging).
 - OTLP exporter for all signals.
 
-When sending data to an Elastic Observability backend, OTLP through the EDOT Collector is recommended for compatibility and is required for full support. EDOT .NET enables OTLP over gRPC as the default for all signals. You can turn off this behavior through [configuration](/reference/edot-dotnet/configuration.md).
+When sending data to an Elastic Observability backend, OTLP through the {{agent}} is recommended for compatibility and is required for full support. Elastic OTel .NET enables OTLP over gRPC as the default for all signals. You can turn off this behavior through [configuration](/reference/edot-dotnet/configuration.md).
 
-All signals are configured to apply EDOT .NET defaults for resource attributes through the `ResourceBuilder`.
+All signals are configured to apply Elastic OTel .NET defaults for resource attributes through the `ResourceBuilder`.
 
 ### Modify defaults for each signal
 
@@ -67,7 +67,7 @@ The following attributes are added in all scenarios (NuGet and zero code install
 | -------------------------- | --------------------------------------------------------------------------- |
 | `service.instance.id`      | Set with a random GUID to ensure runtime metrics dashboard can be filtered. |
 | `telemetry.distro.name`    | Set as `elastic`.                                                           |
-| `telemetry.distro.version` | Set as the version of the EDOT .NET.                                        |
+| `telemetry.distro.version` | Set as the version of Elastic OTel .NET.                                    |
 
 When using the NuGet installation method, transitive dependencies are added for the following contrib resource detector packages:
 
@@ -90,11 +90,11 @@ Instrumentation assembly scanning is not supported for applications using native
 
 ## Defaults for tracing
 
-EDOT .NET applies subtly different defaults depending on the .NET runtime version being targeted.
+Elastic OTel .NET applies subtly different defaults depending on the .NET runtime version being targeted.
 
 ### HTTP traces
 
-On .NET 9 and newer runtimes, EDOT .NET observes the `System.Net.Http` source to collect traces from the .NET HTTP APIs. Since .NET 9, the built-in traces are compliant with current semantic conventions. Using the built-in `System.Net.Http` source is now the recommended choice. If the target application explicitly depends on the `OpenTelemetry.Instrumentation.Http` package, EDOT .NET assumes it should be used instead of the built-in source.
+On .NET 9 and newer runtimes, Elastic OTel .NET observes the `System.Net.Http` source to collect traces from the .NET HTTP APIs. Since .NET 9, the built-in traces are compliant with current semantic conventions. Using the built-in `System.Net.Http` source is now the recommended choice. If the target application explicitly depends on the `OpenTelemetry.Instrumentation.Http` package, Elastic OTel .NET assumes it should be used instead of the built-in source.
 
 :::{note}
 When upgrading applications to .NET 9 and newer, consider removing the package reference to `OpenTelemetry.Instrumentation.Http`.
@@ -116,7 +116,7 @@ All scenarios register the SQL client when instrumentation assembly scanning is 
 
 ### Additional sources
 
-EDOT .NET observes the `Elastic.Transport` source to collect traces from Elastic client libraries, such as `Elastic.Clients.{{es}}`, which is built upon the [Elastic transport](https://github.com/elastic/elastic-transport-net) layer.
+Elastic OTel .NET observes the `Elastic.Transport` source to collect traces from Elastic client libraries, such as `Elastic.Clients.{{es}}`, which is built upon the [Elastic transport](https://github.com/elastic/elastic-transport-net) layer.
 
 ### Instrumentation assembly scanning
 
@@ -147,19 +147,19 @@ Instrumentation assembly scanning is not supported for applications using native
 
 #### ASP.NET Core defaults
 
-To provide a richer experience out-of-the-box, EDOT .NET registers an exception enricher for ASP.NET Core when using instrumentation assembly scanning.
+To provide a richer experience out-of-the-box, Elastic OTel .NET registers an exception enricher for ASP.NET Core when using instrumentation assembly scanning.
 
 When an unhandled exception occurs during a request that ASP.NET Core handles, the exception is added as a span event using the [`AddException`](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.addexception) API from `System.Diagnostics`. Span events are stored as logs in the Observability backend and will appear in the Errors UI. Additionally, when the `Exception.Source` property is not null, its value is added as an attribute `exception.source` on the ASP.NET Core request span.
 
 ## Defaults for metrics
 
-EDOT .NET applies subtly different defaults depending on the .NET runtime version being targeted.
+Elastic OTel .NET applies subtly different defaults depending on the .NET runtime version being targeted.
 
 ### HTTP metrics
 
-On .NET 9 and newer runtimes, EDOT .NET observes the `System.Net.Http` meter to collect metrics from the .NET HTTP APIs. Since .NET 9, the built-in metrics are compliant with current semantic conventions. Using the built-in `System.Net.Http` meter is therefore recommended. 
+On .NET 9 and newer runtimes, Elastic OTel .NET observes the `System.Net.Http` meter to collect metrics from the .NET HTTP APIs. Since .NET 9, the built-in metrics are compliant with current semantic conventions. Using the built-in `System.Net.Http` meter is therefore recommended.
 
-If the target application has an explicit dependency on the `OpenTelemetry.Instrumentation.Http` package,  EDOT .NET assumes that it should be used instead of the built-in meter. 
+If the target application has an explicit dependency on the `OpenTelemetry.Instrumentation.Http` package, Elastic OTel .NET assumes that it should be used instead of the built-in meter. 
 
 :::{note}
 When upgrading applications to .NET 9 and newer, consider removing the package reference to `OpenTelemetry.Instrumentation.Http`.
@@ -169,9 +169,9 @@ On all other runtimes, when using the NuGet installation method, a transitive de
 
 ### Runtime metrics
 
-On .NET 9 and newer runtimes, EDOT .NET observes the `System.Runtime` meter to collect metrics from the .NET HTTP APIs. Since .NET 9, the built-in traces are compliant with current semantic conventions. Using the built-in `System.Runtime` meter is therefore recommended. 
+On .NET 9 and newer runtimes, Elastic OTel .NET observes the `System.Runtime` meter to collect metrics from the .NET HTTP APIs. Since .NET 9, the built-in traces are compliant with current semantic conventions. Using the built-in `System.Runtime` meter is therefore recommended.
 
-If the target application has an explicit dependency on the `OpenTelemetry.Instrumentation.Runtime` package, EDOT .NET assumes that it should be used instead of the built-in meter.
+If the target application has an explicit dependency on the `OpenTelemetry.Instrumentation.Runtime` package, Elastic OTel .NET assumes that it should be used instead of the built-in meter.
 
 :::{note}
 When upgrading applications to .NET 9 and newer, consider removing the package reference to `OpenTelemetry.Instrumentation.Runtime`.
@@ -198,7 +198,7 @@ NuGet package, the following meters are observed by default:
 
 ### Additional meters
 
-EDOT .NET observes the `System.Net.NameResolution` meter, to collect metrics from DNS.
+Elastic OTel .NET observes the `System.Net.NameResolution` meter, to collect metrics from DNS.
 
 ### Instrumentation assembly scanning
 
@@ -221,13 +221,13 @@ Instrumentation assembly scanning is not supported for applications using native
 
 ### Configuration defaults
 
-To ensure the best compatibility of metric data (specifically from the histogram instrument), EDOT .NET defaults the `TemporalityPreference` configuration setting on `MetricReaderOptions` to use the `MetricReaderTemporalityPreference.Delta` temporality.
+To ensure the best compatibility of metric data (specifically from the histogram instrument), Elastic OTel .NET defaults the `TemporalityPreference` configuration setting on `MetricReaderOptions` to use the `MetricReaderTemporalityPreference.Delta` temporality.
 
 ## Defaults for logging
 
-EDOT .NET enables the following options that are not enabled by default when using the OpenTelemetry SDK.
+Elastic OTel .NET enables the following options that are not enabled by default when using the OpenTelemetry SDK.
 
-| Option                   | EDOT .NET default | OpenTelemetry SDK default |
+| Option                   | Elastic OTel .NET default | OpenTelemetry SDK default |
 | ------------------------ | ----------------- | ------------------------- |
 | IncludeFormattedMessage  | `true`            | `false`                   |
 | IncludeScopes            | `true` (Since 1.4.0)      | `false`                   |
@@ -235,7 +235,7 @@ EDOT .NET enables the following options that are not enabled by default when usi
 Activating `IncludeScopes` produces richer log attributes by including .NET log scope data as additional attributes on each log record. Be aware that including scopes can increase log storage volume depending on the scope data your application emits.
 
 :::{note}
-`IncludeScopes` was deactivated between 1.0.2 and 1.3.x as a temporary workaround for a duplicate-attribute issue in the upstream OpenTelemetry SDK. It was reactivated in 1.4.0 once the EDOT Collector and managed OTLP endpoints gained support for deduplicating repeated attributes.
+`IncludeScopes` was deactivated between 1.0.2 and 1.3.x as a temporary workaround for a duplicate-attribute issue in the upstream OpenTelemetry SDK. It was reactivated in 1.4.0 once the {{agent}} and managed OTLP endpoints gained support for deduplicating repeated attributes.
 :::
 
 ### Instrumentation assembly scanning
@@ -243,7 +243,7 @@ Activating `IncludeScopes` produces richer log attributes by including .NET log 
 Instrumentation assembly scanning is enabled by default and is designed to simplify the registration code required to configure the OpenTelemetry SDK. Instrumentation assembly scanning uses reflection to invoke the required registration method for the contrib instrumentation and resource detector packages.
 
 :::{warning}
-Calling the `AddXyzInstrumentation` method in combination with assembly scanning, might not be safe for all instrumentations. When using EDOT .NET, remove the registration of instrumentation to avoid overhead and mitigate the potential for duplicated spans. This has a positive side-effect of simplifying the code you need to manage.
+Calling the `AddXyzInstrumentation` method in combination with assembly scanning, might not be safe for all instrumentations. When using Elastic OTel .NET, remove the registration of instrumentation to avoid overhead and mitigate the potential for duplicated spans. This has a positive side-effect of simplifying the code you need to manage.
 :::
 
 If you need to configure advanced options when registering instrumentation, turn off instrumentation assembly scanning through [Configuration](/reference/edot-dotnet/configuration.md) and prefer manually registering all instrumentation in your application code.

--- a/docs/reference/edot-dotnet/setup/index.md
+++ b/docs/reference/edot-dotnet/setup/index.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Setup
-description: Learn how to set up and configure the Elastic Distribution of OpenTelemetry .NET to instrument your application or service.
+description: Learn how to set up and configure Elastic OTel .NET to instrument your application or service.
 applies_to:
   stack:
   serverless:
@@ -14,21 +14,21 @@ products:
 
 ---
 
-# Set up the EDOT .NET SDK
+# Set up the Elastic OTel .NET SDK [set-up-the-edot-net-sdk]
 
 Learn how to set up and configure the {{edot}} .NET to instrument your application or service.
 
 :::{agent-skill}
 :url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-instrument
 
-Use this skill to instrument .NET services with EDOT for tracing, metrics, and logs.
+Use this skill to instrument .NET services with {{edot}} for tracing, metrics, and logs.
 :::
 
 ## Quickstart guide
 
-EDOT .NET is designed to be straightforward to integrate into your applications. Integration includes applications that have previously used the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/net/), those that are transitioning from the [Elastic APM Agent](apm-agent-dotnet://reference/index.md) and those introducing observability instrumentation for the first time. When the OpenTelemetry SDK or Elastic APM Agent are already in use, minor code changes are required at the point of registration. Refer to [Migration](/reference/edot-dotnet/migration.md) for more details.
+Elastic OTel .NET is designed to be straightforward to integrate into your applications. Integration includes applications that have previously used the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/net/), those that are transitioning from the [Elastic APM Agent](apm-agent-dotnet://reference/index.md) and those introducing observability instrumentation for the first time. When the OpenTelemetry SDK or Elastic APM Agent are already in use, minor code changes are required at the point of registration. Refer to [Migration](/reference/edot-dotnet/migration.md) for more details.
 
-This quickstart guide documents the introductory steps required to set up OpenTelemetry using EDOT .NET for an ASP.NET Core 
+This quickstart guide documents the introductory steps required to set up OpenTelemetry using Elastic OTel .NET for an ASP.NET Core 
 [minimal API](https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis) application. For detailed, technology-specific steps, see:
 
 * [ASP.NET (.NET Framework)](/reference/edot-dotnet/setup/aspnet.md)
@@ -49,7 +49,7 @@ Before getting started:
 * Set up Elastic Observability. You need somewhere to send the gathered OpenTelemetry data so that it can be viewed and analyzed. This documentation assumes you're using [Elastic Cloud](https://www.elastic.co/cloud) with an [Elastic Observability](https://www.elastic.co/observability) hosted deployment or serverless project. You can use an existing one or set up a new one.
 
 :::{tip}
-When using Serverless, use the [{{motlp}}](opentelemetry://reference/motlp.md) for the best experience when using EDOT .NET.
+When using Serverless, use the [{{motlp}}](opentelemetry://reference/motlp.md) for the best experience when using Elastic OTel .NET.
 :::
 
 ### Installing the NuGet packages
@@ -65,7 +65,7 @@ reference to your project file:
 Replace the `<LATEST>` version placeholder with the [latest available package from NuGet.org](https://www.nuget.org/packages/Elastic.OpenTelemetry).
 :::
 
-EDOT .NET includes a transitive dependency on the OpenTelemetry SDK, so you do not need to add the OpenTelemetry SDK package to your project directly. However,
+Elastic OTel .NET includes a transitive dependency on the OpenTelemetry SDK, so you do not need to add the OpenTelemetry SDK package to your project directly. However,
 you can explicitly add the OpenTelemetry SDK as a dependency if you want to opt into newer SDK versions.
 
 #### ASP.NET Core instrumentation
@@ -82,11 +82,11 @@ Manually add the latest version to your project file:
 Replace the `<LATEST>` version placeholder with the [latest available package from NuGet.org](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore).
 :::
 
-The presence of this package is detected by the EDOT instrumentation assembly scanning feature (turned on by default).
+The presence of this package is detected by the Elastic OTel instrumentation assembly scanning feature (turned on by default).
 
-### Registering OpenTelemetry with EDOT .NET
+### Registering OpenTelemetry with Elastic OTel .NET [registering-opentelemetry-with-edot-net]
 
-To register the OpenTelemetry SDK through EDOT .NET, the recommended approach is to use the extension method available on `IHostApplicationBuilder`. `IHostApplicationBuilder` is the abstraction representing the .NET generic host responsible for managing application startup and lifetime in ASP.NET Core.
+To register the OpenTelemetry SDK through Elastic OTel .NET, the recommended approach is to use the extension method available on `IHostApplicationBuilder`. `IHostApplicationBuilder` is the abstraction representing the .NET generic host responsible for managing application startup and lifetime in ASP.NET Core.
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -95,13 +95,13 @@ builder.AddElasticOpenTelemetry();
 
 Immediately after creating the WebApplicationBuilder, which implements `IHostApplicationBuilder`, call the `AddElasticOpenTelemetry` method. `AddElasticOpenTelemetry` registers the OpenTelemetry SDK for .NET, applying the Elastic [opinionated defaults](/reference/edot-dotnet/setup/edot-defaults.md). The Elastic defaults enable tracing, metrics, log signals, and the OTLP exporter.
 
-Additionally, EDOT performs automatic instrumentation assembly scanning to enable the ASP.NET Core instrumentation that we added in the previous step. With the SDK, additional lines of code would be required to register the instrumentation. EDOT .NET aims to simplify the experience of getting started.
+Additionally, Elastic OTel .NET performs automatic instrumentation assembly scanning to enable the ASP.NET Core instrumentation that we added in the previous step. With the SDK, additional lines of code would be required to register the instrumentation. Elastic OTel .NET aims to simplify the experience of getting started.
 
 ### Configure the OpenTelemetry resource attributes
 
 When exporting telemetry data from an application, resource attributes are used to represent metadata about the entity producing the telemetry. While defaults are applied for required attributes such as `service.name`. Explicitly set a descriptive service name to distinguish its data in the Elastic Observability UI.
 
-The OpenTelemetry SDK supports several mechanisms to configure resource attributes. For simple scenarios, the service information can be set programmatically. To achieve this when using EDOT, the `AddElasticOpenTelemetry` method includes an overload accepting an `Action<IOpenTelemetryBuilder>` used to configure the OpenTelemetry SDK through its builder API.
+The OpenTelemetry SDK supports several mechanisms to configure resource attributes. For simple scenarios, the service information can be set programmatically. To achieve this when using Elastic OTel .NET, the `AddElasticOpenTelemetry` method includes an overload accepting an `Action<IOpenTelemetryBuilder>` used to configure the OpenTelemetry SDK through its builder API.
 
 To specify a service name, we can amend the preceding code as follows:
 
@@ -138,7 +138,7 @@ OpenTelemetry configuration environment variables should be specified as a top-l
 
 ### Configure the OTLP endpoint
 
-The configuration documented so far ensures that when the application starts, the OpenTelemetry SDK is launched with the [EDOT .NET defaults](/reference/edot-dotnet/setup/edot-defaults.md), activating all signals and exporting telemetry through OTLP. Unless configured otherwise, the OTLP exporter in the SDK defaults to sending data to `localhost` on the default port for OTLP over gRPC, 4317. If you are running a local Collector, this might be sufficient, but in most cases you will need to configure the correct endpoint for exporting telemetry data.
+The configuration documented so far ensures that when the application starts, the OpenTelemetry SDK is launched with the [Elastic OTel .NET defaults](/reference/edot-dotnet/setup/edot-defaults.md), activating all signals and exporting telemetry through OTLP. Unless configured otherwise, the OTLP exporter in the SDK defaults to sending data to `localhost` on the default port for OTLP over gRPC, 4317. If you are running a local Collector, this might be sufficient, but in most cases you will need to configure the correct endpoint for exporting telemetry data.
 
 In this quickstart guide, {{serverless-full}} is the backend. The onboarding **Add data** page of Elastic Observability provides the environment variables required to send telemetry data to the Elastic Observability backend. This information includes the endpoint URL and API key that should be used when exporting data. The application must be configured to use the endpoint and authorization header when exporting telemetry data.
 
@@ -151,7 +151,7 @@ Strongly consider using a key/secret store for production environments.
 
 ### Instrument application code
 
-EDOT .NET enables the collection of trace, metric, and log signals by default. With no additional configuration, your configured Elastic Observability backend will receive telemetry data from your application at runtime. Development teams are encouraged to enrich the value of telemetry by instrumenting their code to emit application-specific telemetry data such as traces, metrics, and logs. 
+Elastic OTel .NET enables the collection of trace, metric, and log signals by default. With no additional configuration, your configured Elastic Observability backend will receive telemetry data from your application at runtime. Development teams are encouraged to enrich the value of telemetry by instrumenting their code to emit application-specific telemetry data such as traces, metrics, and logs. 
 
 In .NET, use the built-in .NET APIs for each signal:
 
@@ -161,8 +161,8 @@ In .NET, use the built-in .NET APIs for each signal:
 
 ### Next steps
 
-Refer to the technology-specific documentation pages for further details on using EDOT .NET in those application types. The [OpenTelemetry SDK documentation](https://opentelemetry.io/docs/languages/net/getting-started/) provides more examples of working with the .NET SDK.
+Refer to the technology-specific documentation pages for further details on using Elastic OTel .NET in those application types. The [OpenTelemetry SDK documentation](https://opentelemetry.io/docs/languages/net/getting-started/) provides more examples of working with the .NET SDK.
 
 ## Troubleshooting
 
-For help with common setup issues, refer to the [EDOT .NET troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/dotnet/index.md).
+For help with common setup issues, refer to the [Elastic OTel .NET troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/dotnet/index.md).

--- a/docs/reference/edot-dotnet/setup/worker-services.md
+++ b/docs/reference/edot-dotnet/setup/worker-services.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: .NET worker services
-description: Learn how to instrument .NET worker services for Elastic Observability using the Elastic Distribution of OpenTelemetry .NET.
+description: Learn how to instrument .NET worker services for Elastic Observability using Elastic OTel .NET.
 applies_to:
   stack:
   serverless:
@@ -14,9 +14,9 @@ products:
 
 ---
 
-# Set up EDOT .NET for worker services
+# Set up Elastic OTel .NET for worker services [set-up-edot-net-for-worker-services]
 
-When building long-running [worker services](https://learn.microsoft.com/en-us/dotnet/core/extensions/workers) using the Worker Service template, OpenTelemetry is introduced using the same approach as for ASP.NET Core. The recommended way to turn on EDOT .NET is by calling `AddElasticOpenTelemetry` on the `HostApplicationBuilder`.
+When building long-running [worker services](https://learn.microsoft.com/en-us/dotnet/core/extensions/workers) using the Worker Service template, OpenTelemetry is introduced using the same approach as for ASP.NET Core. The recommended way to turn on Elastic OTel .NET is by calling `AddElasticOpenTelemetry` on the `HostApplicationBuilder`.
 
 ```csharp
 using Example.WorkerService;
@@ -34,7 +34,7 @@ host.Run();
 The previous code:
 
 1. Creates a `HostApplicationBuilder` using the `Host.CreateApplicationBuilder` factory method.
-2. Turns on EDOT .NET by calling `AddElasticOpenTelemetry` on the `HostApplicationBuilder`.
+2. Turns on Elastic OTel .NET by calling `AddElasticOpenTelemetry` on the `HostApplicationBuilder`.
 3. Registers application-specific types into the `IServiceCollection`.
 4. Builds and runs the `IHost` to execute the application workload.
 
@@ -208,4 +208,4 @@ The previous code:
 1. Configures tracing using `WithTracing` to add the diagnostic name as a source for trace telemetry we wish to collect and export. The `AddSource` method is called on the builder to configure this.
 2. Configures metrics using `WithMetrics` to add the diagnostic name as a meter for metrics telemetry we wish to collect and export. The `AddMeter` method is called on the builder to configure this.
 
-With these changes in place, this sample application is now instrumented, and for each message processed, a span will be created and exported. We also increment a metric for which the value will be periodically sent. EDOT .NET configures the delta temporality [by default](/reference/edot-dotnet/setup/edot-defaults.md), so each exported value for the counter will be the count since the last export.
+With these changes in place, this sample application is now instrumented, and for each message processed, a span will be created and exported. We also increment a metric for which the value will be periodically sent. Elastic OTel .NET configures the delta temporality [by default](/reference/edot-dotnet/setup/edot-defaults.md), so each exported value for the counter will be the count since the last export.

--- a/docs/reference/edot-dotnet/setup/zero-code.md
+++ b/docs/reference/edot-dotnet/setup/zero-code.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Zero-code instrumentation
-description: Use the EDOT .NET automatic instrumentation to send traces and metrics from .NET applications and services to observability backends without having to modify source code.
+description: Use the Elastic OTel .NET automatic instrumentation to send traces and metrics from .NET applications and services to observability backends without modifying source code.
 applies_to:
   stack:
   serverless:
@@ -16,13 +16,13 @@ products:
 
 # Using profiler-based zero-code instrumentation
 
-EDOT .NET includes a redistribution of the zero-code installer scripts so most of the documentation in the [.NET zero-code instrumentation documentation](https://opentelemetry.io/docs/zero-code/dotnet/) applies.
+Elastic OTel .NET includes a redistribution of the zero-code installer scripts so most of the documentation in the [.NET zero-code instrumentation documentation](https://opentelemetry.io/docs/zero-code/dotnet/) applies.
 
-Use the EDOT .NET automatic instrumentation to send traces and metrics from .NET applications and services to observability backends without having to modify source code.
+Use the Elastic OTel .NET automatic instrumentation to send traces and metrics from .NET applications and services to observability backends without having to modify source code.
 
 ## Compatibility
 
-EDOT .NET automatic instrumentation should work with all officially supported operating systems and versions of .NET. The minimal supported version of .NET Framework is 4.6.2.
+Elastic OTel .NET automatic instrumentation should work with all officially supported operating systems and versions of .NET. The minimal supported version of .NET Framework is 4.6.2.
 
 Supported processor architectures are:
 

--- a/docs/reference/edot-dotnet/supported-technologies.md
+++ b/docs/reference/edot-dotnet/supported-technologies.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Supported technologies
-description: Technologies supported by the Elastic Distribution of OpenTelemetry .NET.
+description: Technologies supported by Elastic OTel .NET.
 applies_to:
   stack:
   serverless:
@@ -13,9 +13,9 @@ products:
   - id: edot-sdk
 ---
 
-# Technologies supported by EDOT .NET SDK
+# Technologies supported by Elastic OTel .NET SDK [technologies-supported-by-edot-net-sdk]
 
-EDOT .NET is a distribution of OpenTelemetry .NET SDK. It inherits all the [supported](opentelemetry://reference/compatibility/nomenclature.md) technologies from the [upstream SDK](https://github.com/open-telemetry/opentelemetry-dotnet).
+Elastic OTel .NET is a distribution of OpenTelemetry .NET SDK. It inherits all the [supported](opentelemetry://reference/compatibility/nomenclature.md) technologies from the [upstream SDK](https://github.com/open-telemetry/opentelemetry-dotnet).
 
 :::{note} - Understanding auto-instrumentation scope
 
@@ -31,15 +31,15 @@ If your application uses technologies not covered by auto-instrumentation, you h
 2. **Manual instrumentation** — Use the [OpenTelemetry API](https://opentelemetry.io/docs/languages/net/instrumentation/) to add custom spans, metrics, and logs for unsupported components.
 :::
 
-## EDOT Collector and Elastic Stack versions
+## {{agent}} and Elastic Stack versions [edot-collector-and-elastic-stack-versions]
 
-EDOT .NET sends data through the OpenTelemetry protocol (OTLP). While OTLP ingest works with later 8.16+ versions of the EDOT Collector, for full support use either the [EDOT Collector](elastic-agent:/reference/edot-collector/index.md) versions 9.x or [{{serverless-full}}](docs-content://deploy-manage/deploy/elastic-cloud/serverless.md) for OTLP ingest.
+Elastic OTel .NET sends data through the OpenTelemetry protocol (OTLP). While OTLP ingest works with later 8.16+ versions of the {{agent}}, for full support use either the [{{agent}}](elastic-agent:/reference/edot-collector/index.md) versions 9.x or [{{serverless-full}}](docs-content://deploy-manage/deploy/elastic-cloud/serverless.md) for OTLP ingest.
 
 :::{note}
-Ingesting data from EDOT SDKs through EDOT Collector 9.x into Elastic Stack versions 8.18+ is supported.
+Ingesting data from Elastic OTel SDKs through {{agent}} 9.x into Elastic Stack versions 8.18+ is supported.
 :::
 
-Refer to [EDOT SDKs compatibility](opentelemetry://reference/compatibility/sdks.md) for support details.
+Refer to [Elastic OTel SDKs compatibility](opentelemetry://reference/compatibility/sdks.md) for support details.
 
 ## .NET Frameworks
 
@@ -66,13 +66,13 @@ and [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy).
 
 Instrumentation for .NET can occur in three ways:
 
-1. Built-in OpenTelemetry native instrumentation, where libraries are instrumented using the .NET APIs, requiring no bridging libraries to be observed. Many Microsoft recent libraries implement OpenTelemetry native instrumentation, and many third parties are working on such improvements. When native OTel instrumentation exists, it may be observed directly by the OpenTelemetry SDK (and, by extension, EDOT .NET) by calling `AddSource` to register the `ActivitySource` used by the instrumented code.
+1. Built-in OpenTelemetry native instrumentation, where libraries are instrumented using the .NET APIs, requiring no bridging libraries to be observed. Many Microsoft recent libraries implement OpenTelemetry native instrumentation, and many third parties are working on such improvements. When native OTel instrumentation exists, it may be observed directly by the OpenTelemetry SDK (and, by extension, Elastic OTel .NET) by calling `AddSource` to register the `ActivitySource` used by the instrumented code.
 
-2. [Contrib instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib) packages. These packages bridge existing telemetry from libraries to emit or enrich OpenTelemetry spans and metrics. Some packages have no dependencies and are included with EDOT .NET [by default](/reference/edot-dotnet/setup/edot-defaults.md). Others, which bring in transitive dependencies, can be added to applications and registered with the OpenTelemetry SDK. EDOT .NET provides an instrumentation assembly scanning feature to register any contrib instrumentation without code changes.
+2. [Contrib instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib) packages. These packages bridge existing telemetry from libraries to emit or enrich OpenTelemetry spans and metrics. Some packages have no dependencies and are included with Elastic OTel .NET [by default](/reference/edot-dotnet/setup/edot-defaults.md). Others, which bring in transitive dependencies, can be added to applications and registered with the OpenTelemetry SDK. Elastic OTel .NET provides an instrumentation assembly scanning feature to register any contrib instrumentation without code changes.
 
-3. Additional instrumentation is available for some components and libraries when using the profiler-based [zero code installation](/reference/edot-dotnet/setup/zero-code.md), for which  EDOT .NET does not add any additional instrumentation. Find the current list supported in the [.NET zero-code documentation](https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/).
+3. Additional instrumentation is available for some components and libraries when using the profiler-based [zero code installation](/reference/edot-dotnet/setup/zero-code.md), for which Elastic OTel .NET does not add any additional instrumentation. Find the current list supported in the [.NET zero-code documentation](https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/).
 
-See also the EDOT .NET [opinionated defaults](/reference/edot-dotnet/setup/edot-defaults.md) for behavior that might differ from the OpenTelemetry NET SDK defaults.
+See also the Elastic OTel .NET [opinionated defaults](/reference/edot-dotnet/setup/edot-defaults.md) for behavior that might differ from the OpenTelemetry NET SDK defaults.
 
 :::{warning}
 Instrumentation assembly scanning is not supported for applications using native [AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot) compilation.
@@ -80,7 +80,7 @@ Instrumentation assembly scanning is not supported for applications using native
 
 ## .NET runtime support
 
-EDOT .NET support all [officially supported](https://dotnet.microsoft.com/en-us/platform/support/policy) versions of [.NET](https://dotnet.microsoft.com/download/dotnet) and
+Elastic OTel .NET support all [officially supported](https://dotnet.microsoft.com/en-us/platform/support/policy) versions of [.NET](https://dotnet.microsoft.com/download/dotnet) and
 [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) (an older Windows-based .NET implementation), except `.NET Framework 3.5`. Due to assembly binding issues introduced by Microsoft, use at least .NET Framework 4.7.2 for best compatibility.
 
 ## Exporting data to Elastic


### PR DESCRIPTION
## Summary

- Prose-only rebrand of all reference documentation for the 9.5 GA release (July 28 2026).
- Replaces `EDOT .NET` → `Elastic OTel .NET`, `EDOT SDK/SDKs` → `Elastic OTel SDK/SDKs`, `EDOT Collector` → `Elastic Agent` (using `{{agent}}` substitute), `EDOT Cloud Forwarder` → `Elastic Cloud Forwarder`, and `Elastic Distribution of OpenTelemetry` → `Elastic OpenTelemetry` (using `{{edot}}` substitute).
- `docset.yml` subs updated: `edot` → `Elastic OpenTelemetry`, `edot-cf` → `Elastic Cloud Forwarder`.
- All renamed headings have explicit anchors added to preserve existing slug-based links.
- Machine IDs unchanged: `edot-dotnet`, `edot-sdk`, `edot-collector`, URL paths, code block identifiers, env vars, package names.
- Release notes (`docs/release-notes/`) left untouched as a historical record for pre-9.5 entries.

## Files touched (12)

`docs/docset.yml`, `docs/reference/edot-dotnet/index.md`, `docs/reference/edot-dotnet/configuration.md`, `docs/reference/edot-dotnet/migration.md`, `docs/reference/edot-dotnet/supported-technologies.md`, `docs/reference/edot-dotnet/setup/index.md`, `docs/reference/edot-dotnet/setup/edot-defaults.md`, `docs/reference/edot-dotnet/setup/aspnet.md`, `docs/reference/edot-dotnet/setup/aspnetcore.md`, `docs/reference/edot-dotnet/setup/console.md`, `docs/reference/edot-dotnet/setup/worker-services.md`, `docs/reference/edot-dotnet/setup/zero-code.md`

## Anchors added to renamed headings

| File | Old heading slug | New heading text |
|------|-----------------|-----------------|
| `index.md` | `elastic-distribution-of-opentelemetry-net` | `# Elastic OTel .NET` |
| `configuration.md` | `configure-the-edot-net-sdk` | `# Configure the Elastic OTel .NET SDK` |
| `migration.md` | `migrate-to-edot-net-from-the-elastic-apm-net-agent` | `# Migrate to Elastic OTel .NET from the Elastic APM .NET agent` |
| `supported-technologies.md` | `technologies-supported-by-edot-net-sdk` | `# Technologies supported by Elastic OTel .NET SDK` |
| `supported-technologies.md` | `edot-collector-and-elastic-stack-versions` | `## Elastic Agent and Elastic Stack versions` |
| `setup/index.md` | `set-up-the-edot-net-sdk` | `# Set up the Elastic OTel .NET SDK` |
| `setup/index.md` | `registering-opentelemetry-with-edot-net` | `### Registering OpenTelemetry with Elastic OTel .NET` |
| `setup/edot-defaults.md` | `edot-net-opinionated-defaults` | `# Elastic OTel .NET opinionated defaults` |
| `setup/aspnet.md` | `set-up-edot-net-for-aspnet-applications-on-net-framework` | `# Set up Elastic OTel .NET for ASP.NET applications on .NET Framework` |
| `setup/aspnet.md` | `register-the-edot-net-and-opentelemetry-sdk` | `## Register the Elastic OTel .NET and OpenTelemetry SDK` |
| `setup/aspnetcore.md` | `set-up-edot-net-for-aspnet-core-applications` | `# Set up Elastic OTel .NET for ASP.NET Core applications` |
| `setup/console.md` | `set-up-edot-net-for-console-applications` | `# Set up Elastic OTel .NET for console applications` |
| `setup/console.md` | `configure-edot-net` | `### Configure Elastic OTel .NET` |
| `setup/worker-services.md` | `set-up-edot-net-for-worker-services` | `# Set up Elastic OTel .NET for worker services` |

## Notes

- Held as **draft** for coordinated merge on July 28 2026 9.5 GA.
- No mermaid diagrams or auto-generated blocks were present in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)