### PR TITLE
Retarget EDOT .NET agent-skill callouts to observability-onboarding

### DIFF
--- a/docs/reference/edot-dotnet/migration.md
+++ b/docs/reference/edot-dotnet/migration.md
@@ -30,6 +30,12 @@ While you can use the [OpenTelemetry SDK for .NET](https://github.com/open-telem
 
 Follow these steps to migrate from the legacy Elastic APM .NET agent to the {{edot}} .NET.
 
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills@observability-onboarding
+
+Use this skill to migrate from the Elastic APM .NET agent to EDOT .NET.
+:::
+
 ### Manual instrumentation
 
 The Elastic APM Agent supports OTel-native trace instrumentation through its [OpenTelemetry Bridge](apm-agent-dotnet://reference/opentelemetry-bridge.md) feature, which is active by default.

--- a/docs/reference/edot-dotnet/migration.md
+++ b/docs/reference/edot-dotnet/migration.md
@@ -31,7 +31,7 @@ While you can use the [OpenTelemetry SDK for .NET](https://github.com/open-telem
 Follow these steps to migrate from the legacy Elastic APM .NET agent to the {{edot}} .NET.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills@observability-onboarding
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding
 
 Use this skill to migrate from the Elastic APM .NET agent to EDOT .NET.
 :::

--- a/docs/reference/edot-dotnet/migration.md
+++ b/docs/reference/edot-dotnet/migration.md
@@ -30,12 +30,6 @@ While you can use the [OpenTelemetry SDK for .NET](https://github.com/open-telem
 
 Follow these steps to migrate from the legacy Elastic APM .NET agent to the {{edot}} .NET.
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-migrate
-
-Use this skill to migrate from the Elastic APM .NET agent to EDOT .NET.
-:::
-
 ### Manual instrumentation
 
 The Elastic APM Agent supports OTel-native trace instrumentation through its [OpenTelemetry Bridge](apm-agent-dotnet://reference/opentelemetry-bridge.md) feature, which is active by default.

--- a/docs/reference/edot-dotnet/setup/index.md
+++ b/docs/reference/edot-dotnet/setup/index.md
@@ -19,7 +19,7 @@ products:
 Learn how to set up and configure the {{edot}} .NET to instrument your application or service.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills@observability-onboarding
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding
 
 Use this skill to instrument .NET services with EDOT for tracing, metrics, and logs.
 :::

--- a/docs/reference/edot-dotnet/setup/index.md
+++ b/docs/reference/edot-dotnet/setup/index.md
@@ -18,6 +18,12 @@ products:
 
 Learn how to set up and configure the {{edot}} .NET to instrument your application or service.
 
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills@observability-onboarding
+
+Use this skill to instrument .NET services with EDOT for tracing, metrics, and logs.
+:::
+
 ## Quickstart guide
 
 EDOT .NET is designed to be straightforward to integrate into your applications. Integration includes applications that have previously used the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/net/), those that are transitioning from the [Elastic APM Agent](apm-agent-dotnet://reference/index.md) and those introducing observability instrumentation for the first time. When the OpenTelemetry SDK or Elastic APM Agent are already in use, minor code changes are required at the point of registration. Refer to [Migration](/reference/edot-dotnet/migration.md) for more details.

--- a/docs/reference/edot-dotnet/setup/index.md
+++ b/docs/reference/edot-dotnet/setup/index.md
@@ -18,12 +18,6 @@ products:
 
 Learn how to set up and configure the {{edot}} .NET to instrument your application or service.
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-dotnet-instrument
-
-Use this skill to instrument .NET services with EDOT for tracing, metrics, and logs.
-:::
-
 ## Quickstart guide
 
 EDOT .NET is designed to be straightforward to integrate into your applications. Integration includes applications that have previously used the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/net/), those that are transitioning from the [Elastic APM Agent](apm-agent-dotnet://reference/index.md) and those introducing observability instrumentation for the first time. When the OpenTelemetry SDK or Elastic APM Agent are already in use, minor code changes are required at the point of registration. Refer to [Migration](/reference/edot-dotnet/migration.md) for more details.


### PR DESCRIPTION
## Summary

elastic/agent-skills [v0.6.0](https://github.com/elastic/agent-skills/releases/tag/v0.6.0) removed `edot-dotnet-instrument` and `edot-dotnet-migrate`. Those skills now live in `observability-onboarding`, which still covers both paths for .NET: attach EDOT when no classic APM agent is present, and migrate off the Elastic APM .NET agent. The attach method (`builder.AddElasticOpenTelemetry()`), environment variables, and do-not-reuse-APM-Server-URL guidance match the old skills.

This PR points the setup and migration `{agent-skill}` callouts at the GitHub folder [`skills/observability/onboarding`](https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding). Page-specific body text is unchanged so setup still orients to instrument, and migration still orients to migrate.

These companion docs use a `/tree/main/skills/...` URL instead of the `repo@skill` form. The `@` URLs 404 if opened as GitHub links, and in these EDOT repos they also break the link the directive embeds.

Companion to elastic/docs-content#8227. Tracked in elastic/docs-content#8230.

## Test plan

- [ ] Preview the setup and migration pages and confirm each callout links to the `observability/onboarding` skill folder.
- [ ] Confirm surrounding setup and migration steps are unchanged.
